### PR TITLE
Add Business Tickets Discovery guided template

### DIFF
--- a/src/components/ScriptPanel.tsx
+++ b/src/components/ScriptPanel.tsx
@@ -1,8 +1,8 @@
-import { Project } from '../lib/storage'
+import { Project, QuestionVariant, ScriptQuestion } from '../lib/storage'
 
 interface ScriptPanelProps {
   project: Project
-  onCaptureAnswer: (questionId: string, variantText: string) => void
+  onCaptureAnswer: (question: ScriptQuestion, variant: QuestionVariant) => void
 }
 
 export default function ScriptPanel({ project, onCaptureAnswer }: ScriptPanelProps) {
@@ -18,17 +18,45 @@ export default function ScriptPanel({ project, onCaptureAnswer }: ScriptPanelPro
           <ul className="mt-3 space-y-2">
             {section.questions.map((question) => (
               <li key={question.id} className="rounded-2xl bg-white/80 p-3 shadow-sm dark:bg-slate-900/60">
-                <p className="text-sm font-semibold text-slate-700 dark:text-slate-100">{question.label}</p>
-                <div className="mt-2 space-y-2">
-                  {question.variants.map((variant) => (
-                    <button
-                      key={variant.id}
-                      onClick={() => onCaptureAnswer(question.id, variant.text)}
-                      className="w-full rounded-2xl bg-indigo-500/10 px-3 py-2 text-left text-xs text-indigo-600 transition hover:bg-indigo-500/20 dark:text-indigo-200"
-                    >
-                      ✨ {variant.text}
-                    </button>
-                  ))}
+                <div className="flex flex-col gap-2">
+                  <div>
+                    <p className="text-sm font-semibold text-slate-700 dark:text-slate-100">{question.label}</p>
+                    {question.tags.length > 0 && (
+                      <div className="mt-1 flex flex-wrap gap-1 text-[10px] uppercase tracking-wide text-indigo-500 dark:text-indigo-200">
+                        {question.tags.map((tag) => (
+                          <span key={tag} className="rounded-full bg-indigo-500/10 px-2 py-0.5">
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                  {question.inputs?.length ? (
+                    <div className="rounded-2xl border border-indigo-200/40 bg-indigo-50/40 p-2 text-[10px] text-slate-600 dark:border-indigo-500/40 dark:bg-slate-900/40 dark:text-slate-300">
+                      <p className="font-semibold text-indigo-600 dark:text-indigo-200">Structured capture:</p>
+                      <ul className="mt-1 space-y-1">
+                        {question.inputs.map((input) => (
+                          <li key={input.id} className="flex items-center justify-between gap-2">
+                            <span>{input.label}</span>
+                            <span className="rounded-full bg-white/70 px-2 py-0.5 text-[9px] uppercase tracking-wide text-indigo-500 dark:bg-slate-800/60 dark:text-indigo-200">
+                              {input.type}
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ) : null}
+                  <div className="space-y-2">
+                    {question.variants.map((variant) => (
+                      <button
+                        key={variant.id}
+                        onClick={() => onCaptureAnswer(question, variant)}
+                        className="w-full rounded-2xl bg-indigo-500/10 px-3 py-2 text-left text-xs text-indigo-600 transition hover:bg-indigo-500/20 dark:text-indigo-200"
+                      >
+                        ✨ {variant.text}
+                      </button>
+                    ))}
+                  </div>
                 </div>
               </li>
             ))}

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -1,5 +1,5 @@
 import { saveAs } from 'file-saver'
-import { Canvas, Card, Project, Template } from './storage'
+import { Canvas, Card, Project, Template, QuestionFieldState } from './storage'
 
 function formatCard(card: Card): string {
   const header = `- [${card.type.toUpperCase()}] ${card.title || 'Untitled'}\n`
@@ -18,6 +18,230 @@ function formatCard(card: Card): string {
   return header + body + extra
 }
 
+function collectBusinessTicketsFields(project: Project) {
+  const fieldMap = new Map<string, QuestionFieldState>()
+  project.canvases.forEach((canvas) => {
+    canvas.cards.forEach((card) => {
+      if (card.type === 'question') {
+        card.fields?.forEach((field) => {
+          fieldMap.set(field.id, field)
+        })
+      }
+    })
+  })
+  return fieldMap
+}
+
+const currencyFormatter = new Intl.NumberFormat(undefined, {
+  style: 'currency',
+  currency: 'USD',
+  maximumFractionDigits: 0
+})
+
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric'
+})
+
+function optionLabel(field: QuestionFieldState): string | undefined {
+  if (typeof field.value !== 'string') return undefined
+  return field.options?.find((option) => option.value === field.value)?.label ?? field.value
+}
+
+function formatCurrencyValue(value: QuestionFieldState['value']): string {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return currencyFormatter.format(value)
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return '—'
+    const numeric = Number(trimmed.replace(/[^0-9.]/g, ''))
+    if (!Number.isNaN(numeric) && numeric > 0) {
+      return currencyFormatter.format(numeric)
+    }
+    return trimmed
+  }
+  return '—'
+}
+
+function formatDateValue(value: QuestionFieldState['value']): string {
+  if (typeof value !== 'string' || !value) return '—'
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    return value
+  }
+  return dateFormatter.format(parsed)
+}
+
+function formatFieldValue(field?: QuestionFieldState): string {
+  if (!field) return '—'
+  switch (field.type) {
+    case 'checkbox':
+      return field.value ? 'Yes' : 'No'
+    case 'select':
+      return optionLabel(field) ?? '—'
+    case 'multiSelect':
+    case 'tags':
+      return Array.isArray(field.value) && field.value.length ? field.value.join(', ') : '—'
+    case 'number':
+      return typeof field.value === 'number' && Number.isFinite(field.value) ? String(field.value) : '—'
+    case 'currency':
+      return formatCurrencyValue(field.value)
+    case 'date':
+      return formatDateValue(field.value)
+    case 'time':
+      return typeof field.value === 'string' && field.value ? field.value : '—'
+    case 'longText':
+    case 'shortText':
+    case 'email':
+    case 'phone':
+      return typeof field.value === 'string' && field.value.trim() ? field.value.trim() : '—'
+    default:
+      return typeof field.value === 'string' && field.value.trim() ? field.value.trim() : '—'
+  }
+}
+
+function fieldString(field?: QuestionFieldState): string {
+  const formatted = formatFieldValue(field)
+  return formatted === '—' ? '' : formatted
+}
+
+function fieldArray(field?: QuestionFieldState): string[] {
+  if (!field) return []
+  if (Array.isArray(field.value)) return field.value
+  return []
+}
+
+function buildBusinessTicketsSummary(project: Project): string[] {
+  const fieldMap = collectBusinessTicketsFields(project)
+  const getField = (id: string) => fieldMap.get(id)
+  const lines: string[] = []
+
+  lines.push(`- Name → ${formatFieldValue(getField('customer_name'))}`)
+
+  const historyField = getField('history_status')
+  const priorAgent = fieldString(getField('prior_agent'))
+  let historySummary = '—'
+  if (historyField) {
+    if (historyField.value === 'yes') {
+      const base = optionLabel(historyField) ?? 'Yes'
+      historySummary = priorAgent ? `${base} • ${priorAgent}` : base
+    } else if (historyField.value === 'no') {
+      historySummary = 'First-time caller'
+    } else if (historyField.value === 'unsure') {
+      historySummary = 'Not sure'
+    } else {
+      historySummary = formatFieldValue(historyField)
+    }
+  }
+  lines.push(`- History with us → ${historySummary}`)
+
+  const sourceLabel = formatFieldValue(getField('source_channel'))
+  const refAgent = fieldString(getField('ref_agent'))
+  lines.push(`- Source → ${sourceLabel}${refAgent ? ` (${refAgent})` : ''}`)
+
+  const fromAirport = fieldString(getField('from_airport')) || '—'
+  const toAirport = fieldString(getField('to_airport')) || '—'
+  const outboundDate = formatFieldValue(getField('out_date'))
+  const returnDate = formatFieldValue(getField('return_date'))
+  const tripType = formatFieldValue(getField('itinerary_type'))
+  lines.push(`- Route/Dates → ${fromAirport} → ${toAirport}, ${outboundDate} / ${returnDate} (${tripType})`)
+
+  const dateFlex = formatFieldValue(getField('date_flex_range'))
+  const dateFlexNotes = fieldString(getField('date_flex_notes'))
+  const departAlternates = fieldArray(getField('alt_depart_airports'))
+  const arriveAlternates = fieldArray(getField('alt_arrive_airports'))
+  const airportNotes = fieldString(getField('airport_flex_notes'))
+  const airportParts: string[] = []
+  if (departAlternates.length) {
+    airportParts.push(`Depart: ${departAlternates.join('/')}`)
+  }
+  if (arriveAlternates.length) {
+    airportParts.push(`Arrive: ${arriveAlternates.join('/')}`)
+  }
+  let airportsSummary = airportParts.join('; ')
+  if (!airportsSummary) airportsSummary = '—'
+  if (airportNotes) {
+    airportsSummary = [airportsSummary !== '—' ? airportsSummary : '', airportNotes].filter(Boolean).join(' • ')
+    if (!airportsSummary) airportsSummary = airportNotes
+  }
+  const dateFlexSummary = dateFlexNotes ? `${dateFlex} (${dateFlexNotes})` : dateFlex
+  lines.push(`- Flexibility → dates ${dateFlexSummary}, airports ${airportsSummary}`)
+
+  const adultField = getField('adult_count')
+  const childField = getField('child_count')
+  const adultCount = typeof adultField?.value === 'number' && Number.isFinite(adultField.value) ? adultField.value : '—'
+  const childCount = typeof childField?.value === 'number' && Number.isFinite(childField.value) ? childField.value : '—'
+  const childAges = fieldString(getField('child_ages')) || '—'
+  lines.push(`- Pax → ${adultCount} adults, ${childCount} children (${childAges})`)
+
+  const cabin = formatFieldValue(getField('cabin_preference'))
+  const usualCabin = formatFieldValue(getField('usual_cabin'))
+  const firstUpgrade = formatFieldValue(getField('consider_first_upgrade'))
+  const mixedCabin = formatFieldValue(getField('mixed_cabin_ok'))
+  const cabinExtras = firstUpgrade !== '—' ? `; first upgrade? ${firstUpgrade}` : ''
+  lines.push(`- Cabin → ${cabin}, usual ${usualCabin}, mixed-cabin OK: ${mixedCabin}${cabinExtras}`)
+
+  const preferredAirlines = formatFieldValue(getField('preferred_airlines'))
+  const avoidAirlines = formatFieldValue(getField('avoid_airlines'))
+  const priorExperience = fieldString(getField('route_experience')) || formatFieldValue(getField('airline_notes'))
+  lines.push(`- Airline prefs/avoids → ${preferredAirlines}/${avoidAirlines}; prior exp: ${priorExperience || '—'}`)
+
+  const milesMatter = formatFieldValue(getField('miles_important'))
+  const programs = formatFieldValue(getField('ffp_programs'))
+  const skipMiles = formatFieldValue(getField('ok_to_skip_miles'))
+  lines.push(`- Miles → important ${milesMatter}, programs ${programs}; ok to skip for price: ${skipMiles}`)
+
+  const stops = formatFieldValue(getField('max_stops'))
+  const minLayover = formatFieldValue(getField('min_layover'))
+  const maxLayover = formatFieldValue(getField('max_layover'))
+  const maxTravel = formatFieldValue(getField('max_travel_time'))
+  lines.push(`- Stops/Timing → stops ${stops}, layover ${minLayover}-${maxLayover}, max total ${maxTravel}`)
+
+  const separateTickets = formatFieldValue(getField('separate_ticket_ok'))
+  lines.push(`- Tradeoffs → separate tickets ${separateTickets}`)
+
+  lines.push(`- Preferences → ${formatFieldValue(getField('must_haves'))}`)
+
+  const wantDetails = formatFieldValue(getField('want_details'))
+  const detailFacets = formatFieldValue(getField('detail_facets'))
+  const detailSummary = detailFacets !== '—' ? `${wantDetails} (${detailFacets})` : wantDetails
+  lines.push(`- Presentation detail level → ${detailSummary}`)
+
+  const bestPrice = fieldString(getField('best_price_seen')) || '—'
+  const whereSeen = fieldString(getField('where_seen'))
+  const marketNotes = fieldString(getField('market_notes'))
+  let marketSummary = bestPrice
+  if (whereSeen) marketSummary += ` @ ${whereSeen}`
+  if (marketNotes) marketSummary += ` • ${marketNotes}`
+  lines.push(`- Market knowledge → ${marketSummary}`)
+
+  const minBudget = formatFieldValue(getField('min_budget'))
+  const maxBudget = formatFieldValue(getField('max_budget'))
+  lines.push(`- Budget → ${minBudget}–${maxBudget}`)
+
+  const bookingTiming = formatFieldValue(getField('booking_timing'))
+  const timingNotes = fieldString(getField('timing_notes'))
+  lines.push(`- Booking timing → ${bookingTiming}${timingNotes ? ` (${timingNotes})` : ''}`)
+
+  lines.push(`- Passenger names → ${formatFieldValue(getField('names_raw'))}`)
+
+  const contactEmail = formatFieldValue(getField('contact_email'))
+  const contactPhone = formatFieldValue(getField('contact_phone'))
+  const smsOk = formatFieldValue(getField('sms_ok'))
+  lines.push(`- Contacts → ${contactEmail}, ${contactPhone}, SMS ${smsOk}`)
+
+  lines.push(`- Recap → ${formatFieldValue(getField('recap'))}`)
+
+  const callbackTime = formatFieldValue(getField('callback_time'))
+  const agreeCallback = formatFieldValue(getField('agree_callback'))
+  const followUp = fieldString(getField('send_company_info'))
+  lines.push(`- Next step → callback ~${callbackTime}, agreed: ${agreeCallback}${followUp ? `; send: ${followUp}` : ''}`)
+
+  return lines
+}
+
 export function exportProjectToJson(project: Project) {
   const blob = new Blob([JSON.stringify(project, null, 2)], { type: 'application/json' })
   saveAs(blob, `${project.name.replace(/\s+/g, '-')}-${new Date().toISOString()}.json`)
@@ -28,6 +252,12 @@ export function exportProjectToText(project: Project) {
   lines.push(`# ${project.name}`)
   lines.push(`Last updated: ${new Date(project.updatedAt).toLocaleString()}`)
   lines.push('')
+  if (project.script.title === 'Business Tickets Discovery') {
+    lines.push('## Q & A (Guided)')
+    lines.push('')
+    lines.push(...buildBusinessTicketsSummary(project))
+    lines.push('')
+  }
   project.canvases.forEach((canvas) => {
     lines.push(`## Canvas: ${canvas.name}`)
     canvas.frames.forEach((frame) => {

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -1,7 +1,7 @@
-import { Template } from './storage'
+import { Template, Script, QuestionVariant } from './storage'
 import { createId } from './id'
 
-function variants(base: string[]): any[] {
+function variants(base: string[]): QuestionVariant[] {
   return base.map((text, index) => ({
     id: createId('variant'),
     text,
@@ -133,6 +133,583 @@ const travelAgentScript = {
             'How would you like us to follow up after this?',
             'What’s the ideal action you’d like to see next?'
           ])
+        }
+      ]
+    }
+  ]
+}
+
+const firstContactChecklistItems = [
+  'Introduce self + Business-Tickets; share why you’re calling',
+  'Confirm traveler’s name and spelling (NATO if needed)',
+  'Ask if this is their first time working with us',
+  'Capture how they found us / referral source',
+  'Confirm From, To, Dates, and OW/RT structure',
+  'Log date flexibility in both directions',
+  'Check airport flexibility for departure and arrival',
+  'Note passenger count; gather children and ages',
+  'Confirm preferred cabin and usual cabin',
+  'Record airline preferences and reasons',
+  'Record airline dislikes and reasons',
+  'Capture prior route or carrier experience',
+  'Document miles importance and programs',
+  'Set limits for max stops, layovers, and total travel time',
+  'Verify mixed-cabin on short legs acceptable',
+  'Verify separate tickets acceptable',
+  'List specific timing or routing preferences',
+  'Note desired detail level when presenting options',
+  'Capture market knowledge / best offer seen so far',
+  'Document budget range',
+  'Record booking timing expectations',
+  'Collect full passenger names as on passport',
+  'Recap key details back to the caller',
+  'Confirm best email/phone and SMS permission',
+  'Re-introduce self; set research & follow-up expectation',
+  'Mention info email; schedule next call and commit to time'
+]
+
+const businessTicketsScript: Script = {
+  id: createId('script'),
+  title: 'Business Tickets Discovery',
+  sections: [
+    {
+      id: createId('section'),
+      title: 'Greeting & Consent',
+      cues: '~30 sec • open warmly and confirm time to chat',
+      questions: [
+        {
+          id: createId('question'),
+          label: 'Quick intro + consent',
+          tags: ['Identity'],
+          variants: variants([
+            "Hey there, it’s {agent} with Business-Tickets—do you have a minute right now?",
+            "Hi, this is {agent} from Business-Tickets. Is this still a good time to connect?",
+            "You’re chatting with {agent} at Business-Tickets—shall we dive in now or circle back later?"
+          ]),
+          inputs: [
+            {
+              id: 'consent_to_chat',
+              label: 'Caller confirmed they can talk now',
+              type: 'checkbox',
+              description: 'Mark once the traveler gives the go-ahead to proceed.'
+            }
+          ]
+        }
+      ]
+    },
+    {
+      id: createId('section'),
+      title: 'Identity & Relationship',
+      cues: '~2 min • confirm how to address them and prior context',
+      questions: [
+        {
+          id: createId('question'),
+          label: 'Preferred name',
+          tags: ['Identity'],
+          variants: variants([
+            'How do you like to be addressed?',
+            "What name should I put in my notes for you?",
+            'If I send a recap, which name should I use?'
+          ]),
+          inputs: [
+            {
+              id: 'customer_name',
+              label: 'Traveler name',
+              type: 'shortText',
+              placeholder: 'Full name or nickname to use'
+            }
+          ]
+        },
+        {
+          id: createId('question'),
+          label: 'History with Business-Tickets',
+          tags: ['Identity'],
+          variants: variants([
+            'Have we helped you before, or is this the first time we’ve connected?',
+            'Curious—have you worked with anyone on our team previously?',
+            'Have you partnered with Business-Tickets before? If so, who looked after you?'
+          ]),
+          inputs: [
+            {
+              id: 'history_status',
+              label: 'Worked with us before',
+              type: 'select',
+              options: [
+                { value: 'yes', label: 'Yes' },
+                { value: 'no', label: 'No' },
+                { value: 'unsure', label: 'Not sure' }
+              ]
+            },
+            {
+              id: 'prior_agent',
+              label: 'Prior agent name',
+              type: 'shortText',
+              placeholder: 'Who did they work with?'
+            },
+            {
+              id: 'routing_preference',
+              label: 'Preference on who assists',
+              type: 'select',
+              options: [
+                { value: 'keep_agent', label: 'Stay with the same agent if possible' },
+                { value: 'any_agent', label: 'Happy with anyone on the team' },
+                { value: 'agent_unavailable', label: 'Open if prior agent is unavailable' },
+                { value: 'no_preference', label: 'No preference' }
+              ]
+            }
+          ]
+        },
+        {
+          id: createId('question'),
+          label: 'How they found us',
+          tags: ['Source'],
+          variants: variants([
+            'Where did Business-Tickets pop up on your radar?',
+            'Did someone refer you, or did you stumble on us elsewhere?',
+            'I’d love to know how we landed on your shortlist—what’s the story?'
+          ]),
+          inputs: [
+            {
+              id: 'source_channel',
+              label: 'Discovery channel',
+              type: 'select',
+              options: [
+                { value: 'google', label: 'Google' },
+                { value: 'ads', label: 'Ads / social' },
+                { value: 'referral_company', label: 'Referral to the company' },
+                { value: 'referral_agent', label: 'Referral to a specific agent' },
+                { value: 'repeat', label: 'Repeat client' },
+                { value: 'other', label: 'Other source' }
+              ]
+            },
+            {
+              id: 'ref_agent',
+              label: 'Referring agent or contact',
+              type: 'shortText',
+              placeholder: 'Name of referrer if shared',
+              description: 'Highlight if they expect a warm handoff to a specific advisor.'
+            }
+          ]
+        }
+      ]
+    },
+    {
+      id: createId('section'),
+      title: 'Trip Blueprint',
+      cues: '~8–10 min • route, schedule, and flexibility',
+      questions: [
+        {
+          id: createId('question'),
+          label: 'Trip snapshot',
+          tags: ['Trip'],
+          variants: variants([
+            "Mind if I sanity-check your route and dates?",
+            'Let me make sure I’ve got the basics right—where are we flying and when?',
+            'Can we lock in the core itinerary together?'
+          ]),
+          inputs: [
+            { id: 'from_airport', label: 'Origin airport', type: 'shortText', placeholder: 'e.g., JFK' },
+            { id: 'to_airport', label: 'Destination airport', type: 'shortText', placeholder: 'e.g., SIN' },
+            { id: 'out_date', label: 'Outbound date', type: 'date' },
+            { id: 'return_date', label: 'Return date', type: 'date', description: 'Leave blank for one-way.' },
+            {
+              id: 'itinerary_type',
+              label: 'Trip type',
+              type: 'select',
+              options: [
+                { value: 'ow', label: 'One-way' },
+                { value: 'rt', label: 'Round trip' },
+                { value: 'oj', label: 'Open-jaw / multi-city' }
+              ]
+            }
+          ]
+        },
+        {
+          id: createId('question'),
+          label: 'Date flexibility',
+          tags: ['Flexibility'],
+          variants: variants([
+            'If fares swing a bit, how much can we slide the dates?',
+            'Are you locked into those dates or is there wiggle room?',
+            'Could we move a day or two if that unlocks better space?'
+          ]),
+          inputs: [
+            {
+              id: 'date_flex_range',
+              label: 'Date flexibility',
+              type: 'select',
+              options: [
+                { value: 'none', label: 'No flexibility' },
+                { value: 'plusminus1', label: '±1 day' },
+                { value: 'plusminus3', label: '±2–3 days' },
+                { value: 'plusminus7', label: '±1 week' }
+              ]
+            },
+            {
+              id: 'date_flex_notes',
+              label: 'Notes on flexibility',
+              type: 'shortText',
+              placeholder: 'Blackout dates or key events'
+            }
+          ]
+        },
+        {
+          id: createId('question'),
+          label: 'Airport flexibility',
+          tags: ['Flexibility'],
+          variants: variants([
+            'Any nearby airports we can consider on either end?',
+            'Open to alternate airports if it means better availability?',
+            'Should we price out sister airports for departure or arrival?'
+          ]),
+          inputs: [
+            {
+              id: 'alt_depart_airports',
+              label: 'Alternate departure airports',
+              type: 'tags',
+              placeholder: 'List codes like EWR, LGA'
+            },
+            {
+              id: 'alt_arrive_airports',
+              label: 'Alternate arrival airports',
+              type: 'tags',
+              placeholder: 'List codes like HND, NGO'
+            },
+            {
+              id: 'airport_flex_notes',
+              label: 'Airport notes',
+              type: 'longText',
+              placeholder: 'Any strict avoids or must-use airports'
+            }
+          ]
+        }
+      ]
+    },
+    {
+      id: createId('section'),
+      title: 'Travel Party & Cabin',
+      cues: '~6 min • travelers, comfort, and loyalty',
+      questions: [
+        {
+          id: createId('question'),
+          label: 'Passengers',
+          tags: ['Pax', 'Passengers'],
+          variants: variants([
+            'How many travelers are we planning seats for?',
+            'Who’s flying—any kids or special considerations?',
+            'Give me the headcount and note any little ones with ages.'
+          ]),
+          inputs: [
+            { id: 'adult_count', label: 'Adults', type: 'number', placeholder: 'Number of adults' },
+            { id: 'child_count', label: 'Children', type: 'number', placeholder: 'Number of children' },
+            { id: 'child_ages', label: 'Children ages', type: 'shortText', placeholder: 'e.g., 3 & 7' }
+          ]
+        },
+        {
+          id: createId('question'),
+          label: 'Cabin preference',
+          tags: ['Cabin', 'Req'],
+          variants: variants([
+            'Which cabin are you leaning toward for this journey?',
+            'Are we thinking business, first, or something else this time?',
+            'Is this a premium cabin trip or do we explore other classes?'
+          ]),
+          inputs: [
+            {
+              id: 'cabin_preference',
+              label: 'Desired cabin',
+              type: 'select',
+              options: [
+                { value: 'first', label: 'First' },
+                { value: 'business', label: 'Business' },
+                { value: 'premium', label: 'Premium economy' },
+                { value: 'economy', label: 'Economy' }
+              ]
+            },
+            {
+              id: 'usual_cabin',
+              label: 'Usual cabin',
+              type: 'select',
+              options: [
+                { value: 'same', label: 'Same as this trip' },
+                { value: 'different', label: 'Usually different cabin' }
+              ]
+            },
+            {
+              id: 'consider_first_upgrade',
+              label: 'Consider first class if ~+$1k?',
+              type: 'checkbox'
+            }
+          ]
+        },
+        {
+          id: createId('question'),
+          label: 'Airline likes and dislikes',
+          tags: ['Airline', 'Preferences'],
+          variants: variants([
+            'Any airlines you love or want us to avoid?',
+            'Who gets your loyalty—and who’s on the no-fly list?',
+            'Are there carriers that feel like a perfect fit or a hard pass?'
+          ]),
+          inputs: [
+            { id: 'preferred_airlines', label: 'Preferred airlines', type: 'tags', placeholder: 'Add preferred carriers' },
+            { id: 'avoid_airlines', label: 'Airlines to avoid', type: 'tags', placeholder: 'Carriers to skip' },
+            { id: 'airline_notes', label: 'Notes', type: 'longText', placeholder: 'Reasons or nuances' }
+          ]
+        },
+        {
+          id: createId('question'),
+          label: 'Route or carrier experience',
+          tags: ['Airline'],
+          variants: variants([
+            'Have you flown this route or airline before? How was it?',
+            'What worked—or didn’t—the last time you flew something similar?',
+            'Any past trips on this corridor that set expectations?'
+          ]),
+          inputs: [
+            { id: 'route_experience', label: 'Prior experience notes', type: 'longText', placeholder: 'Highlights, misses, lessons learned' }
+          ]
+        },
+        {
+          id: createId('question'),
+          label: 'Loyalty & miles',
+          tags: ['Loyalty'],
+          variants: variants([
+            'Is banking miles or status part of the goal here?',
+            'How important is it that this earns with a specific program?',
+            'Which mileage programs matter most for you?'
+          ]),
+          inputs: [
+            { id: 'miles_important', label: 'Miles matter for this trip', type: 'checkbox' },
+            { id: 'ffp_programs', label: 'Programs to credit', type: 'tags', placeholder: 'e.g., SQ PPS, AF Flying Blue' },
+            {
+              id: 'ok_to_skip_miles',
+              label: 'Okay to skip miles if pricing wins',
+              type: 'checkbox'
+            }
+          ]
+        }
+      ]
+    },
+    {
+      id: createId('section'),
+      title: 'Journey Preferences',
+      cues: '~5 min • stops, tradeoffs, and presentation style',
+      questions: [
+        {
+          id: createId('question'),
+          label: 'Stops & timing guardrails',
+          tags: ['Stops', 'Timing'],
+          variants: variants([
+            'How many stops max feel comfortable?',
+            'What’s the sweet spot for layovers and total travel time?',
+            'Any hard limits on connections or time in the air?'
+          ]),
+          inputs: [
+            {
+              id: 'max_stops',
+              label: 'Max stops',
+              type: 'select',
+              options: [
+                { value: 'nonstop', label: '0 (non-stop only)' },
+                { value: 'one', label: '1 stop max' },
+                { value: 'two', label: '2+ stops okay' }
+              ]
+            },
+            { id: 'min_layover', label: 'Minimum layover', type: 'time' },
+            { id: 'max_layover', label: 'Maximum layover', type: 'time' },
+            { id: 'max_travel_time', label: 'Max total travel time', type: 'time' }
+          ]
+        },
+        {
+          id: createId('question'),
+          label: 'Tradeoffs',
+          tags: ['Tradeoffs', 'Objection'],
+          variants: variants([
+            'Would you mix cabins on short hops if it saves a bundle?',
+            'Open to creative ticketing—like separate tickets—if it beats published fares?',
+            'How flexible are you with cabins or ticketing if value is great?'
+          ]),
+          inputs: [
+            { id: 'mixed_cabin_ok', label: 'Okay with mixed-cabin itineraries', type: 'checkbox' },
+            { id: 'separate_ticket_ok', label: 'Okay with separate tickets', type: 'checkbox' },
+            { id: 'tradeoff_notes', label: 'Tradeoff notes', type: 'longText', placeholder: 'Any limits or red lines' }
+          ]
+        },
+        {
+          id: createId('question'),
+          label: 'Specific preferences',
+          tags: ['Preferences'],
+          variants: variants([
+            'Any must-haves or hard avoids I should know upfront?',
+            'Are there times, airports, or routings that are non-negotiable?',
+            'What absolutely needs to happen—or never happen—on this trip?'
+          ]),
+          inputs: [
+            { id: 'must_haves', label: 'Must-haves / avoids', type: 'longText', placeholder: 'Note timing, routing, or service preferences' }
+          ]
+        },
+        {
+          id: createId('question'),
+          label: 'How to present options',
+          tags: ['Presentation'],
+          variants: variants([
+            'When I send options, do you want the full nerdy breakdown or just highlights?',
+            'Should I include aircraft, seat maps, lounges—or keep it high-level?',
+            'How detailed do you like proposal emails to be?'
+          ]),
+          inputs: [
+            { id: 'want_details', label: 'Wants detailed breakdown', type: 'checkbox' },
+            {
+              id: 'detail_facets',
+              label: 'Details to include',
+              type: 'multiSelect',
+              options: [
+                { value: 'aircraft', label: 'Aircraft type' },
+                { value: 'seat', label: 'Seat / suite type' },
+                { value: 'layout', label: 'Cabin layout' },
+                { value: 'catering', label: 'Catering' },
+                { value: 'lounges', label: 'Lounges' },
+                { value: 'airport_ratings', label: 'Airport ratings' }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      id: createId('section'),
+      title: 'Market & Budget Signals',
+      cues: '~4 min • calibrate offers and urgency',
+      questions: [
+        {
+          id: createId('question'),
+          label: 'Market intel',
+          tags: ['Market', 'Next'],
+          variants: variants([
+            'Have you seen any quotes yet? What’s the best so far?',
+            'Any offers you’re already considering that I should beat?',
+            'What’s the top option you’ve seen and where did it come from?'
+          ]),
+          inputs: [
+            { id: 'best_price_seen', label: 'Best price seen', type: 'shortText', placeholder: 'e.g., $4,200 RT' },
+            { id: 'where_seen', label: 'Where spotted', type: 'shortText', placeholder: 'Agency, OTA, airline, etc.' },
+            { id: 'market_notes', label: 'Market notes', type: 'longText', placeholder: 'Strengths or weaknesses of the offer' }
+          ]
+        },
+        {
+          id: createId('question'),
+          label: 'Budget range',
+          tags: ['Budget', 'Req'],
+          variants: variants([
+            'Give me a range so I can curate instead of spam—what feels right?',
+            'What’s the investment window you’re comfortable with?',
+            'If we keep it in a certain budget lane, what does that look like?'
+          ]),
+          inputs: [
+            { id: 'min_budget', label: 'Target low end', type: 'currency', placeholder: 'Minimum budget' },
+            { id: 'max_budget', label: 'Target high end', type: 'currency', placeholder: 'Stretch budget' },
+            { id: 'ok_single_price', label: 'Okay with single target price', type: 'checkbox' }
+          ]
+        },
+        {
+          id: createId('question'),
+          label: 'Booking timing',
+          tags: ['Timing', 'Next'],
+          variants: variants([
+            'When are you hoping to wrap this up? Seats move as inventory shifts.',
+            'What’s the decision window so I can work backward?',
+            'When do you picture pulling the trigger if we find the right fit?'
+          ]),
+          inputs: [
+            {
+              id: 'booking_timing',
+              label: 'Booking horizon',
+              type: 'select',
+              options: [
+                { value: 'today', label: 'Today' },
+                { value: '1-3-days', label: '1–3 days' },
+                { value: 'this-week', label: 'This week' },
+                { value: 'later', label: 'Later / just exploring' }
+              ]
+            },
+            { id: 'timing_notes', label: 'Timing notes', type: 'longText', placeholder: 'Decision makers, approvals, etc.' }
+          ]
+        }
+      ]
+    },
+    {
+      id: createId('section'),
+      title: 'Passenger & Contact Details',
+      cues: '~3 min • accurate names and follow-up info',
+      questions: [
+        {
+          id: createId('question'),
+          label: 'Passenger names',
+          tags: ['Passengers'],
+          variants: variants([
+            'Can you give me the full passport names, even if rough now?',
+            'Let’s list out the traveler names exactly as they appear on IDs.',
+            'Mind sharing a quick roster with exact spellings?'
+          ]),
+          inputs: [
+            { id: 'names_raw', label: 'Names as on passport', type: 'longText', placeholder: 'List each traveler' }
+          ]
+        },
+        {
+          id: createId('question'),
+          label: 'Best contacts',
+          tags: ['Contacts'],
+          variants: variants([
+            'What email and phone should I keep updated?',
+            'Where do you want itinerary drafts and alerts to land?',
+            'Share the best email/phone—and if SMS updates are welcome.'
+          ]),
+          inputs: [
+            { id: 'contact_email', label: 'Primary email', type: 'email', placeholder: 'name@company.com' },
+            { id: 'contact_phone', label: 'Best phone', type: 'phone', placeholder: '+1 415…' },
+            { id: 'sms_ok', label: 'Okay to text updates', type: 'checkbox' }
+          ]
+        }
+      ]
+    },
+    {
+      id: createId('section'),
+      title: 'Recap & Next Steps',
+      cues: '~2 min • confirm summary and follow-up plan',
+      questions: [
+        {
+          id: createId('question'),
+          label: 'Recap',
+          tags: ['Recap'],
+          variants: variants([
+            'Let me replay what I captured—anything I missed?',
+            'Here’s the quick summary—does that line up with your priorities?',
+            'Before we break, did I nail the essentials in my recap?'
+          ]),
+          inputs: [
+            { id: 'recap', label: 'Recap notes', type: 'longText', placeholder: 'Key takeaways for follow-up' }
+          ]
+        },
+        {
+          id: createId('question'),
+          label: 'Next step & follow-up',
+          tags: ['Next'],
+          variants: variants([
+            'I’ll scout fares and circle back—what time works for an update?',
+            'Let me research private fares and ping you—when should I check in?',
+            'I’ll pull options in the next hour or so—good time to reconnect?'
+          ]),
+          inputs: [
+            { id: 'callback_time', label: 'Callback target time', type: 'time' },
+            { id: 'agree_callback', label: 'Client agreed to the callback plan', type: 'checkbox' },
+            {
+              id: 'send_company_info',
+              label: 'Resources to send',
+              type: 'longText',
+              placeholder: 'Company info, sample itineraries, etc.'
+            }
+          ]
         }
       ]
     }
@@ -301,6 +878,26 @@ const supportScript = {
 }
 
 export const builtInTemplates: Template[] = [
+  {
+    id: createId('template'),
+    name: 'Business Tickets Discovery',
+    description: 'Structured discovery for premium-cabin flight searches. Friendly phrasing, branching, and recap/next-steps baked in.',
+    script: businessTicketsScript,
+    personalBullets: [
+      'Flag referral expectations or past agent preference',
+      'Capture cabin, budget, and flexibility guardrails',
+      'Confirm promised follow-up timing'
+    ],
+    defaultCards: [
+      {
+        type: 'checklist',
+        title: 'First-Contact Assessment',
+        checklistItems: firstContactChecklistItems,
+        tags: ['checklist', 'first-contact'],
+        color: '#eef2ff'
+      }
+    ]
+  },
   {
     id: createId('template'),
     name: 'Travel Agent Discovery',


### PR DESCRIPTION
## Summary
- add the Business Tickets Discovery script with structured prompts, inputs, and a bundled First-Contact Assessment checklist
- extend question cards, guided capture, and storage to support structured fields and richer metadata
- update text export to summarize Business Tickets Discovery answers in the requested plain-text format

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4596117688326bfddab1450c2792d