### PR TITLE
Add template selection dialog when creating projects

### DIFF
--- a/src/components/TemplatePickerDialog.tsx
+++ b/src/components/TemplatePickerDialog.tsx
@@ -1,0 +1,69 @@
+import { XMarkIcon } from '@heroicons/react/24/outline'
+import { Template } from '../lib/storage'
+
+interface TemplatePickerDialogProps {
+  open: boolean
+  templates: Template[]
+  onClose: () => void
+  onSelect: (template: Template) => void
+}
+
+export default function TemplatePickerDialog({ open, templates, onClose, onSelect }: TemplatePickerDialogProps) {
+  if (!open) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 backdrop-blur"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose()
+      }}
+    >
+      <div className="relative w-full max-w-4xl rounded-3xl border border-white/20 bg-white/95 p-6 shadow-glow dark:border-slate-800/60 dark:bg-slate-900/95">
+        <button
+          onClick={onClose}
+          className="absolute right-4 top-4 rounded-full bg-white/70 p-2 text-slate-500 shadow-sm transition hover:bg-white hover:text-slate-700 dark:bg-slate-800/70 dark:text-slate-300 dark:hover:bg-slate-800"
+          aria-label="Close template picker"
+        >
+          <XMarkIcon className="h-5 w-5" />
+        </button>
+
+        <header className="mb-6 pr-10">
+          <h2 className="text-2xl font-semibold text-slate-800 dark:text-white">Choose a template</h2>
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            Start your new project with guided questions and canvases tailored to each conversation type.
+          </p>
+        </header>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          {templates.map((template) => (
+            <button
+              key={template.id}
+              onClick={() => onSelect(template)}
+              className="group flex h-full flex-col items-start rounded-3xl border border-slate-200/60 bg-white/80 p-5 text-left shadow-soft transition hover:-translate-y-1 hover:shadow-glow focus:outline-none focus:ring-2 focus:ring-indigo-400 dark:border-slate-700/60 dark:bg-slate-900/80"
+            >
+              <span className="text-sm font-semibold uppercase tracking-wide text-indigo-500 dark:text-indigo-300">Template</span>
+              <h3 className="mt-2 text-xl font-semibold text-slate-800 group-hover:text-indigo-600 dark:text-white dark:group-hover:text-indigo-300">
+                {template.name}
+              </h3>
+              <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">{template.description}</p>
+              {template.personalBullets.length > 0 && (
+                <ul className="mt-4 space-y-2 text-sm text-slate-500 dark:text-slate-400">
+                  {template.personalBullets.slice(0, 3).map((bullet) => (
+                    <li key={bullet} className="flex items-start gap-2">
+                      <span className="mt-1 h-2 w-2 rounded-full bg-indigo-400"></span>
+                      <span>{bullet}</span>
+                    </li>
+                  ))}
+                  {template.personalBullets.length > 3 && <li className="text-xs text-slate-400">and more...</li>}
+                </ul>
+              )}
+              <span className="mt-4 inline-flex items-center gap-2 rounded-full bg-indigo-500/10 px-3 py-1 text-xs font-semibold text-indigo-600 transition group-hover:bg-indigo-500/20 dark:bg-indigo-500/20 dark:text-indigo-200">
+                Use this template
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -3,13 +3,13 @@ import { useNavigate } from 'react-router-dom'
 import { PlusIcon, SparklesIcon, DocumentDuplicateIcon, TrashIcon } from '@heroicons/react/24/outline'
 import { StoreContext } from '../App'
 import { strings } from '../lib/i18n'
-import { Template } from '../lib/storage'
+import TemplatePickerDialog from '../components/TemplatePickerDialog'
 
 export default function Home() {
   const store = useContext(StoreContext)!
   const navigate = useNavigate()
   const [searchTerm, setSearchTerm] = useState('')
-  const [template, setTemplate] = useState<Template | undefined>(store.templates[0])
+  const [isTemplateDialogOpen, setTemplateDialogOpen] = useState(false)
 
   const filtered = useMemo(() => {
     const term = searchTerm.toLowerCase()
@@ -30,21 +30,9 @@ export default function Home() {
           </p>
         </div>
         <div className="ml-auto flex flex-wrap items-center gap-3">
-          <select
-            value={template?.id}
-            onChange={(event) => setTemplate(store.templates.find((tpl) => tpl.id === event.target.value))}
-            className="rounded-2xl border border-indigo-200 bg-white/80 px-3 py-2 text-sm shadow-soft focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-300 dark:border-slate-700/50 dark:bg-slate-900/70"
-          >
-            {store.templates.map((tpl) => (
-              <option key={tpl.id} value={tpl.id}>
-                {tpl.name}
-              </option>
-            ))}
-          </select>
           <button
             onClick={() => {
-              const project = store.addProject(template)
-              if (project) navigate(`/project/${project.id}`)
+              setTemplateDialogOpen(true)
             }}
             className="inline-flex items-center gap-2 rounded-2xl bg-gradient-to-r from-indigo-500 to-violet-500 px-4 py-2 text-sm font-semibold text-white shadow-soft hover:shadow-glow"
           >
@@ -120,6 +108,19 @@ export default function Home() {
           </div>
         )}
       </div>
+
+      <TemplatePickerDialog
+        open={isTemplateDialogOpen}
+        templates={store.templates}
+        onClose={() => setTemplateDialogOpen(false)}
+        onSelect={(tpl) => {
+          const project = store.addProject(tpl)
+          if (project) {
+            setTemplateDialogOpen(false)
+            navigate(`/project/${project.id}`)
+          }
+        }}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add a template picker dialog so project creation happens after choosing a template
- hook the dialog into the home view so selected templates create and open projects immediately

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e45f37f404832690b5708e1aef5b75