### PR TITLE
Add live site link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A delightful, offline-first workspace for sales and success teams to capture guided discovery notes. Built with React, TypeScript, Tailwind, Framer Motion, and local-first storage so it runs perfectly on GitHub Pages.
 
+👉 **Live site:** https://vtoool.github.io/VNote/
+
 ## Features
 
 - ✨ Project dashboard with template-based project creation, fuzzy search, duplication, and friendly empty states.


### PR DESCRIPTION
## Summary
- add a prominent link to the deployed GitHub Pages site in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e463310a8483269819ccd071e8b641