### PR TITLE
Improve mobile responsiveness across the app

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { createContext, useEffect, useMemo, useState } from 'react'
 import { Navigate, Route, Routes, useNavigate } from 'react-router-dom'
-import { CommandLineIcon } from '@heroicons/react/24/outline'
+import { CommandLineIcon, MagnifyingGlassIcon, XMarkIcon } from '@heroicons/react/24/outline'
 import { useLocalStore } from './hooks/useLocalStore'
 import { applyTheme, loadTheme, saveTheme, ThemeState } from './lib/theme'
 import { exportProjectToJson, exportProjectToText } from './lib/export'
@@ -23,22 +23,78 @@ export const StoreContext = createContext<StoreContextValue | null>(null)
 
 function Header({ onOpenCommand }: { onOpenCommand: () => void }) {
   const navigate = useNavigate()
+  const [mobileSearchOpen, setMobileSearchOpen] = useState(false)
+
+  useEffect(() => {
+    if (!mobileSearchOpen) return
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setMobileSearchOpen(false)
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [mobileSearchOpen])
+
   return (
-    <header className="glass-panel sticky top-4 z-40 mx-auto flex w-full max-w-5xl items-center gap-3 px-5 py-3">
-      <button
-        onClick={() => navigate('/')}
-        className="rounded-2xl bg-slate-900/5 px-3 py-1 text-sm font-semibold text-slate-700 dark:text-slate-100"
-      >
-        {strings.appTitle}
-      </button>
-      <SearchBar />
-      <button
-        onClick={onOpenCommand}
-        className="ml-auto inline-flex items-center gap-2 rounded-2xl bg-indigo-500/10 px-3 py-2 text-sm font-medium text-indigo-600 hover:bg-indigo-500/20 dark:text-indigo-200"
-      >
-        <CommandLineIcon className="h-4 w-4" />
-        Cmd / Ctrl + K
-      </button>
+    <header className="glass-panel sticky top-4 z-40 mx-auto flex w-full max-w-5xl flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:gap-4 sm:px-5">
+      <div className="flex w-full items-center gap-2">
+        <button
+          onClick={() => navigate('/')}
+          className="rounded-2xl bg-slate-900/5 px-3 py-1 text-sm font-semibold text-slate-700 transition hover:bg-slate-900/10 dark:bg-white/10 dark:text-slate-100"
+        >
+          {strings.appTitle}
+        </button>
+        <div className="ml-auto flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setMobileSearchOpen(true)}
+            className="inline-flex items-center justify-center rounded-2xl bg-slate-900/5 p-2 text-slate-600 transition hover:bg-slate-900/10 dark:bg-white/10 dark:text-slate-200 sm:hidden"
+            aria-label="Open search"
+          >
+            <MagnifyingGlassIcon className="h-5 w-5" />
+          </button>
+          <button
+            type="button"
+            onClick={onOpenCommand}
+            className="inline-flex items-center gap-2 rounded-2xl bg-indigo-500/10 px-3 py-2 text-sm font-medium text-indigo-600 transition hover:bg-indigo-500/20 dark:text-indigo-200"
+            aria-label="Open command palette"
+          >
+            <CommandLineIcon className="h-4 w-4" />
+            <span className="hidden sm:inline">Cmd / Ctrl + K</span>
+          </button>
+        </div>
+      </div>
+      <div className="hidden w-full sm:block">
+        <SearchBar />
+      </div>
+
+      {mobileSearchOpen && (
+        <div
+          className="fixed inset-0 z-50 flex flex-col gap-4 bg-slate-900/80 px-4 py-16 backdrop-blur-sm sm:hidden"
+          onClick={() => setMobileSearchOpen(false)}
+        >
+          <div
+            className="glass-panel mx-auto w-full max-w-lg rounded-3xl p-4"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="flex items-center gap-2">
+              <SearchBar
+                autoFocus
+                containerClassName="max-w-none"
+                inputClassName="py-3 text-base"
+                onNavigate={() => setMobileSearchOpen(false)}
+              />
+              <button
+                type="button"
+                onClick={() => setMobileSearchOpen(false)}
+                className="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-slate-900/5 text-slate-600 transition hover:bg-slate-900/10 dark:bg-white/10 dark:text-slate-200"
+                aria-label="Close search"
+              >
+                <XMarkIcon className="h-5 w-5" />
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </header>
   )
 }

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -5,20 +5,33 @@ import { StoreContext } from '../App'
 import { search } from '../lib/search'
 import { strings } from '../lib/i18n'
 
-export default function SearchBar() {
+type SearchBarProps = {
+  autoFocus?: boolean
+  containerClassName?: string
+  inputClassName?: string
+  onNavigate?: () => void
+}
+
+export default function SearchBar({
+  autoFocus = false,
+  containerClassName,
+  inputClassName,
+  onNavigate
+}: SearchBarProps = {}) {
   const store = useContext(StoreContext)!
   const navigate = useNavigate()
   const [term, setTerm] = useState('')
   const results = useMemo(() => (term ? search(store.projects, term) : []), [store.projects, term])
 
   return (
-    <div className="relative w-full max-w-md">
+    <div className={`relative w-full ${containerClassName ?? 'max-w-md'}`}>
       <MagnifyingGlassIcon className="pointer-events-none absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-slate-400" />
       <input
         value={term}
         onChange={(event) => setTerm(event.target.value)}
         placeholder={strings.searchPlaceholder}
-        className="w-full rounded-2xl border-0 bg-slate-900/5 py-2 pl-10 pr-4 text-sm text-slate-700 focus:outline-none focus:ring-2 focus:ring-indigo-400 dark:bg-white/10 dark:text-slate-100"
+        className={`w-full rounded-2xl border-0 bg-slate-900/5 py-2 pl-10 pr-4 text-sm text-slate-700 focus:outline-none focus:ring-2 focus:ring-indigo-400 dark:bg-white/10 dark:text-slate-100 ${inputClassName ?? ''}`}
+        autoFocus={autoFocus}
       />
       {term && results.length > 0 && (
         <div className="glass-panel absolute left-0 right-0 top-12 max-h-80 overflow-y-auto p-3 text-sm">
@@ -33,6 +46,7 @@ export default function SearchBar() {
                       navigate(`/project/${result.projectId}`)
                     }
                     setTerm('')
+                    onNavigate?.()
                   }}
                   className="w-full rounded-2xl px-3 py-2 text-left hover:bg-indigo-500/10"
                 >

--- a/src/components/TemplatePickerDialog.tsx
+++ b/src/components/TemplatePickerDialog.tsx
@@ -13,55 +13,60 @@ export default function TemplatePickerDialog({ open, templates, onClose, onSelec
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 backdrop-blur"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 px-4 py-6 backdrop-blur"
       onClick={(event) => {
         if (event.target === event.currentTarget) onClose()
       }}
     >
-      <div className="relative w-full max-w-4xl rounded-3xl border border-white/20 bg-white/95 p-6 shadow-glow dark:border-slate-800/60 dark:bg-slate-900/95">
-        <button
-          onClick={onClose}
-          className="absolute right-4 top-4 rounded-full bg-white/70 p-2 text-slate-500 shadow-sm transition hover:bg-white hover:text-slate-700 dark:bg-slate-800/70 dark:text-slate-300 dark:hover:bg-slate-800"
-          aria-label="Close template picker"
-        >
-          <XMarkIcon className="h-5 w-5" />
-        </button>
+      <div className="relative flex h-full w-full max-w-4xl flex-col overflow-hidden rounded-3xl border border-white/20 bg-white/95 shadow-glow dark:border-slate-800/60 dark:bg-slate-900/95">
+        <div className="flex items-center justify-between border-b border-white/40 px-5 py-4 dark:border-slate-800/60">
+          <div className="pr-6">
+            <h2 className="text-lg font-semibold text-slate-800 dark:text-white sm:text-2xl">Choose a template</h2>
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+              Start your new project with guided questions and canvases tailored to each conversation type.
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/70 text-slate-500 shadow-sm transition hover:bg-white hover:text-slate-700 dark:bg-slate-800/70 dark:text-slate-300 dark:hover:bg-slate-800"
+            aria-label="Close template picker"
+          >
+            <XMarkIcon className="h-5 w-5" />
+          </button>
+        </div>
 
-        <header className="mb-6 pr-10">
-          <h2 className="text-2xl font-semibold text-slate-800 dark:text-white">Choose a template</h2>
-          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-            Start your new project with guided questions and canvases tailored to each conversation type.
-          </p>
-        </header>
-
-        <div className="grid gap-4 sm:grid-cols-2">
-          {templates.map((template) => (
-            <button
-              key={template.id}
-              onClick={() => onSelect(template)}
-              className="group flex h-full flex-col items-start rounded-3xl border border-slate-200/60 bg-white/80 p-5 text-left shadow-soft transition hover:-translate-y-1 hover:shadow-glow focus:outline-none focus:ring-2 focus:ring-indigo-400 dark:border-slate-700/60 dark:bg-slate-900/80"
-            >
-              <span className="text-sm font-semibold uppercase tracking-wide text-indigo-500 dark:text-indigo-300">Template</span>
-              <h3 className="mt-2 text-xl font-semibold text-slate-800 group-hover:text-indigo-600 dark:text-white dark:group-hover:text-indigo-300">
-                {template.name}
-              </h3>
-              <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">{template.description}</p>
-              {template.personalBullets.length > 0 && (
-                <ul className="mt-4 space-y-2 text-sm text-slate-500 dark:text-slate-400">
-                  {template.personalBullets.slice(0, 3).map((bullet) => (
-                    <li key={bullet} className="flex items-start gap-2">
-                      <span className="mt-1 h-2 w-2 rounded-full bg-indigo-400"></span>
-                      <span>{bullet}</span>
-                    </li>
-                  ))}
-                  {template.personalBullets.length > 3 && <li className="text-xs text-slate-400">and more...</li>}
-                </ul>
-              )}
-              <span className="mt-4 inline-flex items-center gap-2 rounded-full bg-indigo-500/10 px-3 py-1 text-xs font-semibold text-indigo-600 transition group-hover:bg-indigo-500/20 dark:bg-indigo-500/20 dark:text-indigo-200">
-                Use this template
-              </span>
-            </button>
-          ))}
+        <div className="flex-1 overflow-y-auto px-4 py-5 sm:px-6 sm:py-6">
+          <div className="grid gap-4 sm:grid-cols-2">
+            {templates.map((template) => (
+              <button
+                key={template.id}
+                onClick={() => onSelect(template)}
+                className="group flex h-full flex-col items-start rounded-3xl border border-slate-200/60 bg-white/80 p-5 text-left shadow-soft transition hover:-translate-y-1 hover:shadow-glow focus:outline-none focus:ring-2 focus:ring-indigo-400 dark:border-slate-700/60 dark:bg-slate-900/80"
+              >
+                <span className="text-xs font-semibold uppercase tracking-wide text-indigo-500 dark:text-indigo-300 sm:text-sm">
+                  Template
+                </span>
+                <h3 className="mt-2 text-lg font-semibold text-slate-800 group-hover:text-indigo-600 dark:text-white dark:group-hover:text-indigo-300 sm:text-xl">
+                  {template.name}
+                </h3>
+                <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">{template.description}</p>
+                {template.personalBullets.length > 0 && (
+                  <ul className="mt-4 space-y-2 text-sm text-slate-500 dark:text-slate-400">
+                    {template.personalBullets.slice(0, 3).map((bullet) => (
+                      <li key={bullet} className="flex items-start gap-2">
+                        <span className="mt-1 h-2 w-2 rounded-full bg-indigo-400"></span>
+                        <span>{bullet}</span>
+                      </li>
+                    ))}
+                    {template.personalBullets.length > 3 && <li className="text-xs text-slate-400">and more...</li>}
+                  </ul>
+                )}
+                <span className="mt-4 inline-flex items-center gap-2 rounded-full bg-indigo-500/10 px-3 py-1 text-xs font-semibold text-indigo-600 transition group-hover:bg-indigo-500/20 dark:bg-indigo-500/20 dark:text-indigo-200">
+                  Use this template
+                </span>
+              </button>
+            ))}
+          </div>
         </div>
       </div>
     </div>

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -21,20 +21,20 @@ export default function Home() {
   }, [searchTerm, store.projects])
 
   return (
-    <div className="space-y-6">
-      <div className="glass-panel flex flex-wrap items-center gap-4 p-6">
-        <div>
-          <h1 className="text-2xl font-semibold text-slate-800 dark:text-white">{strings.projectsTitle}</h1>
+    <div className="space-y-5 sm:space-y-6">
+      <div className="glass-panel flex flex-col gap-4 p-4 sm:flex-row sm:flex-wrap sm:items-center sm:gap-4 sm:p-6">
+        <div className="space-y-1">
+          <h1 className="text-xl font-semibold text-slate-800 dark:text-white sm:text-2xl">{strings.projectsTitle}</h1>
           <p className="text-sm text-slate-500 dark:text-slate-400">
             Guided, human-first notes for your high-impact conversations.
           </p>
         </div>
-        <div className="ml-auto flex flex-wrap items-center gap-3">
+        <div className="flex flex-1 items-center justify-end gap-3 sm:flex-none">
           <button
             onClick={() => {
               setTemplateDialogOpen(true)
             }}
-            className="inline-flex items-center gap-2 rounded-2xl bg-gradient-to-r from-indigo-500 to-violet-500 px-4 py-2 text-sm font-semibold text-white shadow-soft hover:shadow-glow"
+            className="inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-indigo-500 to-violet-500 px-4 py-2 text-sm font-semibold text-white shadow-soft transition hover:shadow-glow sm:w-auto"
           >
             <PlusIcon className="h-5 w-5" />
             {strings.createProject}
@@ -42,7 +42,7 @@ export default function Home() {
         </div>
       </div>
 
-      <div className="glass-panel p-6">
+      <div className="glass-panel p-4 sm:p-6">
         <input
           value={searchTerm}
           onChange={(event) => setSearchTerm(event.target.value)}
@@ -50,7 +50,7 @@ export default function Home() {
           className="mb-4 w-full rounded-2xl border border-slate-200/60 bg-white/70 px-4 py-2 text-sm focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400 dark:border-slate-700/50 dark:bg-slate-900/70"
         />
         {filtered.length === 0 ? (
-          <div className="flex flex-col items-center justify-center space-y-3 rounded-3xl border border-dashed border-indigo-300/50 bg-indigo-50/40 p-12 text-center dark:border-indigo-500/40 dark:bg-slate-800/40">
+          <div className="flex flex-col items-center justify-center space-y-3 rounded-3xl border border-dashed border-indigo-300/50 bg-indigo-50/40 p-10 text-center text-sm dark:border-indigo-500/40 dark:bg-slate-800/40 sm:p-12 sm:text-base">
             <SparklesIcon className="h-10 w-10 text-indigo-500" />
             <p className="text-lg font-semibold text-slate-700 dark:text-slate-100">{strings.emptyProjects}</p>
           </div>
@@ -59,19 +59,19 @@ export default function Home() {
             {filtered.map((project) => (
               <article
                 key={project.id}
-                className="group flex flex-col rounded-3xl border border-white/60 bg-white/70 p-6 shadow-soft transition hover:-translate-y-1 hover:shadow-glow dark:border-slate-800/60 dark:bg-slate-900/70"
+                className="group flex flex-col rounded-3xl border border-white/60 bg-white/70 p-5 shadow-soft transition hover:-translate-y-1 hover:shadow-glow dark:border-slate-800/60 dark:bg-slate-900/70 sm:p-6"
               >
-                <header className="flex items-start justify-between gap-3">
-                  <div>
-                    <h2 className="text-xl font-semibold text-slate-800 dark:text-white">{project.name}</h2>
+                <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="space-y-1">
+                    <h2 className="text-lg font-semibold text-slate-800 dark:text-white sm:text-xl">{project.name}</h2>
                     <p className="text-xs text-slate-500 dark:text-slate-400">
                       Updated {new Date(project.updatedAt).toLocaleString()}
                     </p>
                   </div>
-                  <div className="flex gap-2">
+                  <div className="flex flex-wrap gap-2 sm:flex-nowrap">
                     <button
                       onClick={() => navigate(`/project/${project.id}`)}
-                      className="rounded-2xl bg-indigo-500/10 px-3 py-2 text-xs font-semibold text-indigo-600 hover:bg-indigo-500/20 dark:text-indigo-200"
+                      className="rounded-2xl bg-indigo-500/10 px-3 py-2 text-xs font-semibold text-indigo-600 transition hover:bg-indigo-500/20 dark:text-indigo-200"
                     >
                       Open
                     </button>


### PR DESCRIPTION
## Summary
- add a mobile search overlay and responsive header controls for small screens
- refine the home dashboard spacing and actions to better fit handheld layouts
- redesign the template picker dialog and search bar API for touch-friendly usage

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4647d223c83268331e5a4b2306bbe