### PR TITLE
Improve canvas ergonomics and guided mode layout

### DIFF
--- a/src/components/CanvasBoard.tsx
+++ b/src/components/CanvasBoard.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { Rnd } from 'react-rnd'
 import { motion } from 'framer-motion'
 import { Card, Canvas } from '../lib/storage'
 import CardComponent from './Card'
+import type { PointerEvent as ReactPointerEvent } from 'react'
 
 interface CanvasBoardProps {
   canvas: Canvas
@@ -13,6 +14,48 @@ interface CanvasBoardProps {
 
 export default function CanvasBoard({ canvas, onChange, onCardChange, onCardDelete }: CanvasBoardProps) {
   const [showGrid, setShowGrid] = useState(true)
+  const [isPanning, setIsPanning] = useState(false)
+  const panStartRef = useRef<{
+    pointerId: number
+    originX: number
+    originY: number
+    canvasX: number
+    canvasY: number
+  } | null>(null)
+
+  const handlePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0 || event.target !== event.currentTarget) return
+    event.preventDefault()
+    event.currentTarget.setPointerCapture(event.pointerId)
+    setIsPanning(true)
+    panStartRef.current = {
+      pointerId: event.pointerId,
+      originX: event.clientX,
+      originY: event.clientY,
+      canvasX: canvas.position.x,
+      canvasY: canvas.position.y
+    }
+  }
+
+  const handlePointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!isPanning || !panStartRef.current) return
+    event.preventDefault()
+    const { originX, originY, canvasX, canvasY } = panStartRef.current
+    const nextPosition = {
+      x: canvasX + (event.clientX - originX),
+      y: canvasY + (event.clientY - originY)
+    }
+    onChange({ ...canvas, position: nextPosition })
+  }
+
+  const endPan = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!panStartRef.current) return
+    if (event.currentTarget.hasPointerCapture(panStartRef.current.pointerId)) {
+      event.currentTarget.releasePointerCapture(panStartRef.current.pointerId)
+    }
+    panStartRef.current = null
+    setIsPanning(false)
+  }
 
   return (
     <div
@@ -44,16 +87,20 @@ export default function CanvasBoard({ canvas, onChange, onCardChange, onCardDele
         </button>
       </div>
       <motion.div
-        className={`absolute inset-0 ${showGrid ? 'bg-[radial-gradient(circle,_rgba(148,163,184,0.12)_1px,_transparent_0)] bg-[length:48px_48px]' : ''}`}
+        className={`absolute inset-0 ${showGrid ? 'bg-[radial-gradient(circle,_rgba(79,70,229,0.22)_1.5px,_transparent_0)] bg-[length:36px_36px]' : ''} ${isPanning ? 'cursor-grabbing' : 'cursor-grab'}`}
         animate={{ scale: canvas.zoom, x: canvas.position.x, y: canvas.position.y }}
         transition={{ type: 'spring', stiffness: 120, damping: 20 }}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={endPan}
+        onPointerCancel={endPan}
+        style={{ touchAction: 'none' }}
       >
         {canvas.cards.map((card) => (
           <Rnd
             key={card.id}
             position={{ x: card.x, y: card.y }}
             size={{ width: card.width, height: card.height }}
-            bounds="parent"
             onDragStop={(event, data) => {
               onCardChange({ ...card, x: data.x, y: data.y, updatedAt: new Date().toISOString() })
             }}
@@ -70,6 +117,20 @@ export default function CanvasBoard({ canvas, onChange, onCardChange, onCardDele
             enableResizing={!card.locked}
             disableDragging={card.locked}
             style={{ zIndex: card.pinned ? 20 : undefined }}
+            minWidth={200}
+            minHeight={160}
+            resizeHandleStyles={{
+              bottomRight: {
+                width: '16px',
+                height: '16px',
+                borderRadius: '9999px',
+                border: '2px solid rgba(255,255,255,0.8)',
+                background: 'rgba(79,70,229,0.85)',
+                right: '8px',
+                bottom: '8px',
+                boxShadow: '0 4px 10px rgba(79,70,229,0.35)'
+              }
+            }}
           >
             <CardComponent card={card} onChange={onCardChange} onDelete={() => onCardDelete(card.id)} />
           </Rnd>

--- a/src/routes/Canvas.tsx
+++ b/src/routes/Canvas.tsx
@@ -199,12 +199,14 @@ export default function CanvasRoute() {
             <button onClick={() => addCard('media')} className="rounded-2xl bg-white/80 px-3 py-2 text-xs font-semibold text-slate-600 shadow-sm hover:bg-white dark:bg-slate-900/60 dark:text-slate-200">Media</button>
             <button onClick={() => addCard('text')} className="rounded-2xl bg-white/80 px-3 py-2 text-xs font-semibold text-slate-600 shadow-sm hover:bg-white dark:bg-slate-900/60 dark:text-slate-200">Text</button>
           </div>
-          <CanvasBoard
-            canvas={workingCanvas}
-            onChange={updateCanvas}
-            onCardChange={updateCard}
-            onCardDelete={deleteCard}
-          />
+          <div className="lg:sticky lg:top-24">
+            <CanvasBoard
+              canvas={workingCanvas}
+              onChange={updateCanvas}
+              onCardChange={updateCard}
+              onCardDelete={deleteCard}
+            />
+          </div>
           <div className="grid gap-4 md:grid-cols-2">
             <ObjectionsLog cards={workingCanvas.cards} />
             <MutualActionPlan onExport={(items) => {
@@ -219,7 +221,7 @@ export default function CanvasRoute() {
             }} />
           </div>
         </div>
-        <div className="space-y-4">
+        <div className="space-y-4 lg:sticky lg:top-24 lg:max-h-[calc(100vh-6rem)] lg:overflow-y-auto lg:pr-2">
           <ScriptPanel project={project} onCaptureAnswer={handleCaptureAnswer} />
           <PersonalBullets bullets={project.personalBullets} />
           <HelpShortcuts />


### PR DESCRIPTION
## Summary
- keep the canvas visible while browsing guidance by making the board sticky on wide screens and giving the guided mode column its own scroll container
- enhance canvas interaction with panning, higher contrast grid, and minimum card dimensions plus a visible resize handle

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e51cfcfee08326a97bfc00e5835611