### PR TITLE
Add guided call mode workflow and improve canvas interactions

### DIFF
--- a/src/components/CallModePanel.tsx
+++ b/src/components/CallModePanel.tsx
@@ -1,0 +1,695 @@
+import { useEffect, useMemo, useState } from 'react'
+import CanvasBoard from './CanvasBoard'
+import {
+  Card,
+  Canvas,
+  Project,
+  QuestionFieldState,
+  QuestionVariant,
+  ScriptQuestion,
+  ScriptSection
+} from '../lib/storage'
+import { createQuestionCard, initializeFieldState } from '../lib/questions'
+import { quickTags } from '../lib/tags'
+import { createId } from '../lib/id'
+
+interface CallModePanelProps {
+  project: Project
+  canvas: Canvas
+  onCanvasChange: (canvas: Canvas) => void
+  onCardChange: (card: Card) => void
+  onCardDelete: (cardId: string) => void
+  onClose: () => void
+}
+
+interface QuestionPointer {
+  sectionId: string
+  questionId: string
+}
+
+interface HistoryEntry {
+  id: string
+  questionId: string
+  questionLabel: string
+  variantText?: string
+  answer?: string
+  tags: string[]
+  timestamp: string
+  fields?: QuestionFieldState[]
+  skipped?: boolean
+}
+
+function formatElapsed(startedAt: number, now: number) {
+  const totalSeconds = Math.max(0, Math.floor((now - startedAt) / 1000))
+  const minutes = String(Math.floor(totalSeconds / 60)).padStart(2, '0')
+  const seconds = String(totalSeconds % 60).padStart(2, '0')
+  return `${minutes}:${seconds}`
+}
+
+function findFirstQuestion(sections: ScriptSection[], answered: Set<string>): QuestionPointer | null {
+  for (const section of sections) {
+    for (const question of section.questions) {
+      if (!answered.has(question.id)) {
+        return { sectionId: section.id, questionId: question.id }
+      }
+    }
+  }
+  return null
+}
+
+function findNextSequential(
+  pointer: QuestionPointer,
+  sections: ScriptSection[],
+  answered: Set<string>
+): QuestionPointer | null {
+  const sectionIndex = sections.findIndex((section) => section.id === pointer.sectionId)
+  if (sectionIndex === -1) return findFirstQuestion(sections, answered)
+  const questionIndex = sections[sectionIndex].questions.findIndex((q) => q.id === pointer.questionId)
+  if (questionIndex === -1) return findFirstQuestion(sections, answered)
+
+  for (let si = sectionIndex; si < sections.length; si++) {
+    const section = sections[si]
+    const start = si === sectionIndex ? questionIndex + 1 : 0
+    for (let qi = start; qi < section.questions.length; qi++) {
+      const candidate = section.questions[qi]
+      if (!answered.has(candidate.id)) {
+        return { sectionId: section.id, questionId: candidate.id }
+      }
+    }
+  }
+  return null
+}
+
+function determineNextPointer(
+  pointer: QuestionPointer,
+  question: ScriptQuestion,
+  sections: ScriptSection[],
+  answered: Set<string>,
+  activeTags: Set<string>
+): QuestionPointer | null {
+  if (question.branch) {
+    const branchTag = question.branch.whenTag.toLowerCase()
+    if (activeTags.has(branchTag)) {
+      const targetSection = sections.find((section) => section.id === question.branch!.nextSectionId)
+      if (targetSection) {
+        const branchQuestion = targetSection.questions.find((candidate) => !answered.has(candidate.id))
+        if (branchQuestion) {
+          return { sectionId: targetSection.id, questionId: branchQuestion.id }
+        }
+      }
+    }
+  }
+
+  const sequential = findNextSequential(pointer, sections, answered)
+  if (sequential) return sequential
+
+  return findFirstQuestion(sections, answered)
+}
+
+function collectSequentialSuggestions(
+  pointer: QuestionPointer | null,
+  sections: ScriptSection[],
+  answered: Set<string>,
+  limit: number
+) {
+  if (!pointer) return [] as { section: ScriptSection; question: ScriptQuestion }[]
+  const sectionIndex = sections.findIndex((section) => section.id === pointer.sectionId)
+  if (sectionIndex === -1) return []
+  const questionIndex = sections[sectionIndex].questions.findIndex((q) => q.id === pointer.questionId)
+  const suggestions: { section: ScriptSection; question: ScriptQuestion }[] = []
+  if (questionIndex === -1) return suggestions
+
+  for (let si = sectionIndex; si < sections.length && suggestions.length < limit; si++) {
+    const section = sections[si]
+    const start = si === sectionIndex ? questionIndex + 1 : 0
+    for (let qi = start; qi < section.questions.length && suggestions.length < limit; qi++) {
+      const candidate = section.questions[qi]
+      if (!answered.has(candidate.id)) {
+        suggestions.push({ section, question: candidate })
+      }
+    }
+  }
+  return suggestions
+}
+
+function formatFieldValue(field: QuestionFieldState) {
+  if (Array.isArray(field.value)) {
+    return field.value.join(', ') || '—'
+  }
+  if (typeof field.value === 'boolean') {
+    return field.value ? 'Yes' : 'No'
+  }
+  if (typeof field.value === 'number') {
+    return Number.isFinite(field.value) ? String(field.value) : '—'
+  }
+  return field.value ? String(field.value) : '—'
+}
+
+export default function CallModePanel({
+  project,
+  canvas,
+  onCanvasChange,
+  onCardChange,
+  onCardDelete,
+  onClose
+}: CallModePanelProps) {
+  const sections = project.script.sections
+  const totalQuestions = useMemo(
+    () => sections.reduce((count, section) => count + section.questions.length, 0),
+    [sections]
+  )
+  const [history, setHistory] = useState<HistoryEntry[]>([])
+  const answeredSet = useMemo(() => new Set(history.map((entry) => entry.questionId)), [history])
+  const [currentPointer, setCurrentPointer] = useState<QuestionPointer | null>(() =>
+    findFirstQuestion(sections, new Set())
+  )
+  const [sessionStartedAt, setSessionStartedAt] = useState(() => Date.now())
+  const [now, setNow] = useState(() => Date.now())
+  const [answer, setAnswer] = useState('')
+  const [selectedVariantId, setSelectedVariantId] = useState<string | null>(null)
+  const [selectedTags, setSelectedTags] = useState<string[]>([])
+  const [fieldsState, setFieldsState] = useState<QuestionFieldState[]>([])
+
+  useEffect(() => {
+    const interval = window.setInterval(() => setNow(Date.now()), 1000)
+    return () => window.clearInterval(interval)
+  }, [])
+
+  useEffect(() => {
+    if (!currentPointer) {
+      const next = findFirstQuestion(sections, answeredSet)
+      if (next) {
+        setCurrentPointer(next)
+      }
+    }
+  }, [sections, answeredSet, currentPointer])
+
+  const currentSection = currentPointer
+    ? sections.find((section) => section.id === currentPointer.sectionId)
+    : undefined
+  const currentQuestion = currentSection?.questions.find(
+    (question) => question.id === currentPointer?.questionId
+  )
+  const recommendedTagSet = useMemo(
+    () => new Set(currentQuestion?.tags.map((tag) => tag.toLowerCase()) ?? []),
+    [currentQuestion?.id]
+  )
+  const availableTags = useMemo(() => {
+    const defaults = currentQuestion?.tags.map((tag) => tag.toLowerCase()) ?? []
+    return Array.from(new Set([...defaults, ...quickTags]))
+  }, [currentQuestion?.id])
+
+  useEffect(() => {
+    if (!currentQuestion) {
+      setSelectedVariantId(null)
+      setAnswer('')
+      setSelectedTags([])
+      setFieldsState([])
+      return
+    }
+    setSelectedVariantId(currentQuestion.variants[0]?.id ?? null)
+    setAnswer('')
+    setSelectedTags(currentQuestion.tags.map((tag) => tag.toLowerCase()))
+    setFieldsState(currentQuestion.inputs?.map((input) => initializeFieldState(input)) ?? [])
+  }, [currentQuestion?.id])
+
+  const currentVariant = currentQuestion
+    ? currentQuestion.variants.find((variant) => variant.id === selectedVariantId) ||
+      currentQuestion.variants[0]
+    : undefined
+
+  const activeTags = useMemo(() => {
+    const base = currentQuestion?.tags.map((tag) => tag.toLowerCase()) ?? []
+    return new Set([...base, ...selectedTags.map((tag) => tag.toLowerCase())])
+  }, [selectedTags, currentQuestion?.id])
+
+  const sequentialSuggestions = useMemo(() => {
+    const answered = new Set(answeredSet)
+    if (currentQuestion) answered.add(currentQuestion.id)
+    return collectSequentialSuggestions(currentPointer, sections, answered, 3)
+  }, [answeredSet, currentPointer, currentQuestion?.id, sections])
+
+  const progressCount = history.filter((entry) => !entry.skipped).length
+  const elapsed = formatElapsed(sessionStartedAt, now)
+
+  const toggleTag = (tag: string) => {
+    setSelectedTags((prev) =>
+      prev.includes(tag) ? prev.filter((existing) => existing !== tag) : [...prev, tag]
+    )
+  }
+
+  const updateField = (fieldId: string, value: QuestionFieldState['value']) => {
+    setFieldsState((prev) =>
+      prev.map((field) =>
+        field.id === fieldId
+          ? { ...field, value }
+          : field
+      )
+    )
+  }
+
+  const handleSubmit = () => {
+    if (!currentQuestion || !currentSection) return
+    const variantForCard: QuestionVariant =
+      currentVariant ?? { id: `${currentQuestion.id}-default`, text: currentQuestion.label, tone: 'warm' }
+    const card = createQuestionCard({
+      question: currentQuestion,
+      variant: variantForCard,
+      answer: answer.trim(),
+      extraTags: selectedTags,
+      fields: fieldsState.length ? fieldsState : undefined
+    })
+    onCanvasChange({ ...canvas, cards: [card, ...canvas.cards] })
+    const tagSet = new Set(card.tags.map((tag) => tag.toLowerCase()))
+    const entry: HistoryEntry = {
+      id: createId('call-entry'),
+      questionId: currentQuestion.id,
+      questionLabel: currentQuestion.label,
+      variantText: variantForCard.text,
+      answer: answer.trim(),
+      tags: card.tags,
+      timestamp: new Date().toISOString(),
+      fields: card.type === 'question' ? card.fields : undefined,
+      skipped: false
+    }
+    setHistory((prev) => [...prev, entry])
+    const answered = new Set(answeredSet)
+    answered.add(currentQuestion.id)
+    const nextPointer = determineNextPointer(
+      { sectionId: currentSection.id, questionId: currentQuestion.id },
+      currentQuestion,
+      sections,
+      answered,
+      tagSet
+    )
+    setCurrentPointer(nextPointer)
+    setAnswer('')
+    setSelectedTags(currentQuestion.tags.map((tag) => tag.toLowerCase()))
+  }
+
+  const handleSkip = () => {
+    if (!currentQuestion || !currentSection) return
+    const entry: HistoryEntry = {
+      id: createId('call-entry'),
+      questionId: currentQuestion.id,
+      questionLabel: currentQuestion.label,
+      tags: Array.from(activeTags),
+      timestamp: new Date().toISOString(),
+      skipped: true
+    }
+    setHistory((prev) => [...prev, entry])
+    const answered = new Set(answeredSet)
+    answered.add(currentQuestion.id)
+    const nextPointer = determineNextPointer(
+      { sectionId: currentSection.id, questionId: currentQuestion.id },
+      currentQuestion,
+      sections,
+      answered,
+      new Set(activeTags)
+    )
+    setCurrentPointer(nextPointer)
+  }
+
+  const handleRestart = () => {
+    setHistory([])
+    setSessionStartedAt(Date.now())
+    setCurrentPointer(findFirstQuestion(sections, new Set()))
+    setAnswer('')
+    setSelectedTags([])
+    setFieldsState([])
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="glass-panel flex flex-wrap items-center justify-between gap-3 p-4">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-indigo-500">Call mode</p>
+          <p className="text-sm text-slate-600 dark:text-slate-300">
+            {progressCount} of {totalQuestions} questions captured • {elapsed}
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={handleRestart}
+            className="rounded-2xl bg-white/80 px-3 py-2 text-xs font-semibold text-slate-600 shadow-sm hover:bg-white dark:bg-slate-900/60 dark:text-slate-200"
+          >
+            Restart session
+          </button>
+          <button
+            onClick={onClose}
+            className="rounded-2xl bg-rose-500/10 px-3 py-2 text-xs font-semibold text-rose-500 transition hover:bg-rose-500/20"
+          >
+            End call
+          </button>
+        </div>
+      </div>
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)]">
+        <div className="space-y-4">
+          <CanvasBoard
+            canvas={canvas}
+            onChange={onCanvasChange}
+            onCardChange={onCardChange}
+            onCardDelete={onCardDelete}
+          />
+        </div>
+        <div className="space-y-4 lg:pr-2">
+          <section className="glass-panel space-y-4 p-4">
+            {currentQuestion ? (
+              <>
+                <header className="space-y-1">
+                  <p className="text-xs uppercase tracking-wide text-indigo-500">
+                    {currentSection?.title || 'Current question'}
+                  </p>
+                  <h2 className="text-lg font-semibold text-slate-800 dark:text-slate-100">
+                    {currentQuestion.label}
+                  </h2>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">{currentSection?.cues}</p>
+                </header>
+                <div className="space-y-3">
+                  {currentQuestion.variants.length > 0 && (
+                    <div className="space-y-2">
+                      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                        Pick your phrasing
+                      </p>
+                      <div className="space-y-2">
+                        {currentQuestion.variants.map((variant) => (
+                          <label
+                            key={variant.id}
+                            className={`flex cursor-pointer items-start gap-2 rounded-2xl border px-3 py-2 text-xs shadow-sm transition ${
+                              currentVariant?.id === variant.id
+                                ? 'border-indigo-400 bg-indigo-50/80 text-indigo-600 dark:border-indigo-500/60 dark:bg-slate-900/60 dark:text-indigo-200'
+                                : 'border-slate-200/60 bg-white/70 text-slate-600 hover:border-indigo-200 hover:bg-indigo-50/60 dark:border-slate-700/60 dark:bg-slate-900/60 dark:text-slate-300'
+                            }`}
+                          >
+                            <input
+                              type="radio"
+                              name="call-variant"
+                              value={variant.id}
+                              checked={currentVariant?.id === variant.id}
+                              onChange={() => setSelectedVariantId(variant.id)}
+                              className="mt-1"
+                            />
+                            <span>✨ {variant.text}</span>
+                          </label>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  <div className="space-y-2">
+                    <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      Capture the answer
+                    </label>
+                    <textarea
+                      value={answer}
+                      onChange={(event) => setAnswer(event.target.value)}
+                      rows={4}
+                      placeholder="Type what you heard…"
+                      className="w-full rounded-3xl border border-indigo-200/50 bg-white/90 p-3 text-sm shadow-inner focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-300 dark:border-slate-700/60 dark:bg-slate-900/70 dark:text-slate-100"
+                    />
+                  </div>
+                  {fieldsState.length > 0 && (
+                    <div className="space-y-3 rounded-3xl bg-indigo-500/5 p-3">
+                      <p className="text-xs font-semibold uppercase tracking-wide text-indigo-500 dark:text-indigo-200">
+                        Structured capture
+                      </p>
+                      <div className="space-y-3">
+                        {fieldsState.map((field) => {
+                          switch (field.type) {
+                            case 'checkbox':
+                              return (
+                                <label
+                                  key={field.id}
+                                  className="flex items-center gap-2 text-xs font-medium text-slate-600 dark:text-slate-200"
+                                >
+                                  <input
+                                    type="checkbox"
+                                    checked={Boolean(field.value)}
+                                    onChange={(event) => updateField(field.id, event.target.checked)}
+                                    className="rounded border-slate-300 text-indigo-500 focus:ring-indigo-400"
+                                  />
+                                  {field.label}
+                                </label>
+                              )
+                            case 'select':
+                              return (
+                                <div key={field.id} className="space-y-1 text-xs">
+                                  <label className="font-semibold text-slate-600 dark:text-slate-200" htmlFor={field.id}>
+                                    {field.label}
+                                  </label>
+                                  <select
+                                    id={field.id}
+                                    value={typeof field.value === 'string' ? field.value : ''}
+                                    onChange={(event) => updateField(field.id, event.target.value)}
+                                    className="w-full rounded-2xl border border-indigo-300/40 bg-white/80 px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-indigo-400 dark:border-slate-700/50 dark:bg-slate-900/60"
+                                  >
+                                    <option value="">Select…</option>
+                                    {field.options?.map((option) => (
+                                      <option key={option.value} value={option.value}>
+                                        {option.label}
+                                      </option>
+                                    ))}
+                                  </select>
+                                </div>
+                              )
+                            case 'multiSelect':
+                            case 'tags':
+                              return (
+                                <div key={field.id} className="space-y-1 text-xs">
+                                  <label className="font-semibold text-slate-600 dark:text-slate-200" htmlFor={field.id}>
+                                    {field.label}
+                                  </label>
+                                  <input
+                                    id={field.id}
+                                    value={Array.isArray(field.value) ? field.value.join(', ') : ''}
+                                    onChange={(event) =>
+                                      updateField(
+                                        field.id,
+                                        event.target.value
+                                          .split(',')
+                                          .map((entry) => entry.trim())
+                                          .filter(Boolean)
+                                      )
+                                    }
+                                    placeholder={field.placeholder || 'Separate values with commas'}
+                                    className="w-full rounded-2xl border border-indigo-300/40 bg-white/80 px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-indigo-400 dark:border-slate-700/50 dark:bg-slate-900/60"
+                                  />
+                                </div>
+                              )
+                            case 'number':
+                              return (
+                                <div key={field.id} className="space-y-1 text-xs">
+                                  <label className="font-semibold text-slate-600 dark:text-slate-200" htmlFor={field.id}>
+                                    {field.label}
+                                  </label>
+                                  <input
+                                    id={field.id}
+                                    type="number"
+                                    value={typeof field.value === 'number' ? field.value : ''}
+                                    onChange={(event) =>
+                                      updateField(field.id, event.target.value === '' ? null : Number(event.target.value))
+                                    }
+                                    placeholder={field.placeholder}
+                                    className="w-full rounded-2xl border border-indigo-300/40 bg-white/80 px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-indigo-400 dark:border-slate-700/50 dark:bg-slate-900/60"
+                                  />
+                                </div>
+                              )
+                            case 'date':
+                            case 'time':
+                              return (
+                                <div key={field.id} className="space-y-1 text-xs">
+                                  <label className="font-semibold text-slate-600 dark:text-slate-200" htmlFor={field.id}>
+                                    {field.label}
+                                  </label>
+                                  <input
+                                    id={field.id}
+                                    type={field.type}
+                                    value={typeof field.value === 'string' ? field.value : ''}
+                                    onChange={(event) => updateField(field.id, event.target.value)}
+                                    className="w-full rounded-2xl border border-indigo-300/40 bg-white/80 px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-indigo-400 dark:border-slate-700/50 dark:bg-slate-900/60"
+                                  />
+                                </div>
+                              )
+                            case 'longText':
+                              return (
+                                <div key={field.id} className="space-y-1 text-xs">
+                                  <label className="font-semibold text-slate-600 dark:text-slate-200" htmlFor={field.id}>
+                                    {field.label}
+                                  </label>
+                                  <textarea
+                                    id={field.id}
+                                    value={typeof field.value === 'string' ? field.value : ''}
+                                    onChange={(event) => updateField(field.id, event.target.value)}
+                                    placeholder={field.placeholder}
+                                    className="h-20 w-full rounded-2xl border border-indigo-300/40 bg-white/80 p-2 text-xs focus:outline-none focus:ring-2 focus:ring-indigo-400 dark:border-slate-700/50 dark:bg-slate-900/60"
+                                  />
+                                </div>
+                              )
+                            default:
+                              return (
+                                <div key={field.id} className="space-y-1 text-xs">
+                                  <label className="font-semibold text-slate-600 dark:text-slate-200" htmlFor={field.id}>
+                                    {field.label}
+                                  </label>
+                                  <input
+                                    id={field.id}
+                                    type={field.type === 'currency' || field.type === 'shortText' ? 'text' : field.type}
+                                    value={typeof field.value === 'string' ? field.value : ''}
+                                    onChange={(event) => updateField(field.id, event.target.value)}
+                                    placeholder={field.placeholder}
+                                    className="w-full rounded-2xl border border-indigo-300/40 bg-white/80 px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-indigo-400 dark:border-slate-700/50 dark:bg-slate-900/60"
+                                  />
+                                </div>
+                              )
+                          }
+                        })}
+                      </div>
+                    </div>
+                  )}
+                  <div className="space-y-2">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      Tag the moment
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                      {availableTags.map((tag) => (
+                        <button
+                          key={tag}
+                          type="button"
+                          onClick={() => toggleTag(tag)}
+                          className={`rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-wide transition ${
+                            selectedTags.includes(tag)
+                              ? 'bg-indigo-500 text-white shadow'
+                              : 'bg-indigo-500/10 text-indigo-500 hover:bg-indigo-500/20 dark:bg-slate-800/60 dark:text-indigo-200'
+                          } ${recommendedTagSet.has(tag) ? 'ring-1 ring-indigo-400/60' : ''}`}
+                        >
+                          {tag}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                  {currentQuestion.branch && (
+                    <div className="rounded-2xl bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+                      Branch available: if tagged “{currentQuestion.branch.whenTag}”, jump to {
+                        sections.find((section) => section.id === currentQuestion.branch?.nextSectionId)?.title || 'next section'
+                      }
+                    </div>
+                  )}
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      onClick={handleSubmit}
+                      className="rounded-2xl bg-indigo-500 px-4 py-2 text-xs font-semibold text-white shadow hover:bg-indigo-600"
+                    >
+                      Save answer & next
+                    </button>
+                    <button
+                      onClick={handleSkip}
+                      className="rounded-2xl bg-slate-200 px-4 py-2 text-xs font-semibold text-slate-600 hover:bg-slate-300 dark:bg-slate-800/70 dark:text-slate-300 dark:hover:bg-slate-700/70"
+                    >
+                      Skip question
+                    </button>
+                  </div>
+                </div>
+                {sequentialSuggestions.length > 0 && (
+                  <div className="rounded-3xl border border-slate-200/60 bg-white/70 p-3 text-xs dark:border-slate-700/60 dark:bg-slate-900/60">
+                    <p className="font-semibold text-slate-600 dark:text-slate-200">Upcoming</p>
+                    <ul className="mt-2 space-y-1">
+                      {sequentialSuggestions.map((item) => (
+                        <li key={item.question.id} className="text-slate-500 dark:text-slate-400">
+                          <span className="font-semibold text-indigo-500 dark:text-indigo-200">{item.section.title}</span> → {item.question.label}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </>
+            ) : (
+              <div className="space-y-3 text-center">
+                <h2 className="text-lg font-semibold text-slate-800 dark:text-slate-100">Call complete</h2>
+                <p className="text-sm text-slate-500 dark:text-slate-400">
+                  Every scripted question is captured. Review the history below or restart the session.
+                </p>
+                <button
+                  onClick={handleRestart}
+                  className="rounded-2xl bg-indigo-500 px-4 py-2 text-xs font-semibold text-white shadow hover:bg-indigo-600"
+                >
+                  Restart
+                </button>
+              </div>
+            )}
+          </section>
+          <section className="glass-panel max-h-[70vh] overflow-y-auto p-4">
+            <header className="mb-3 flex items-center justify-between">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                Call history
+              </h3>
+              <span className="text-xs text-slate-400 dark:text-slate-500">{history.length} entries</span>
+            </header>
+            {history.length === 0 ? (
+              <p className="rounded-2xl bg-slate-100/60 p-3 text-xs text-slate-400 dark:bg-slate-800/60 dark:text-slate-500">
+                Answers and skipped prompts will appear here as you move through the script.
+              </p>
+            ) : (
+              <ul className="space-y-3 text-sm">
+                {history
+                  .slice()
+                  .reverse()
+                  .map((entry) => (
+                    <li
+                      key={entry.id}
+                      className="rounded-3xl border border-slate-200/60 bg-white/80 p-3 shadow-sm dark:border-slate-700/60 dark:bg-slate-900/60"
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <p className="text-xs uppercase tracking-wide text-indigo-500">
+                            {new Date(entry.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                          </p>
+                          <p className="text-sm font-semibold text-slate-700 dark:text-slate-100">
+                            {entry.questionLabel}
+                          </p>
+                        </div>
+                        {entry.skipped ? (
+                          <span className="rounded-full bg-amber-500/10 px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-amber-600 dark:text-amber-300">
+                            Skipped
+                          </span>
+                        ) : (
+                          <span className="rounded-full bg-indigo-500/10 px-2 py-1 text-[11px] font-semibold uppercase tracking-wide text-indigo-500 dark:text-indigo-200">
+                            Captured
+                          </span>
+                        )}
+                      </div>
+                      {entry.variantText && (
+                        <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">Prompt: {entry.variantText}</p>
+                      )}
+                      {!entry.skipped && entry.answer && (
+                        <p className="mt-2 rounded-2xl bg-indigo-500/5 p-2 text-sm text-slate-700 dark:bg-slate-800/60 dark:text-slate-200">
+                          {entry.answer}
+                        </p>
+                      )}
+                      {entry.fields && entry.fields.length > 0 && (
+                        <div className="mt-2 space-y-1 text-xs text-slate-500 dark:text-slate-400">
+                          {entry.fields.map((field) => (
+                            <p key={field.id}>
+                              <span className="font-semibold text-slate-600 dark:text-slate-200">{field.label}:</span>{' '}
+                              {formatFieldValue(field)}
+                            </p>
+                          ))}
+                        </div>
+                      )}
+                      {entry.tags.length > 0 && (
+                        <div className="mt-2 flex flex-wrap gap-1 text-[10px] uppercase tracking-wide text-indigo-500 dark:text-indigo-200">
+                          {entry.tags.map((tag) => (
+                            <span key={tag} className="rounded-full bg-indigo-500/10 px-2 py-0.5">
+                              {tag}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </li>
+                  ))}
+              </ul>
+            )}
+          </section>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/CanvasBoard.tsx
+++ b/src/components/CanvasBoard.tsx
@@ -30,7 +30,11 @@ export default function CanvasBoard({ canvas, onChange, onCardChange, onCardDele
   } | null>(null)
 
   const handlePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
-    if (event.button !== 0 || event.target !== event.currentTarget) return
+    if (event.button !== 0) return
+    const target = event.target as HTMLElement | null
+    if (target && target.closest('[data-card-root="true"]')) {
+      return
+    }
     event.preventDefault()
     event.currentTarget.setPointerCapture(event.pointerId)
     setIsPanning(true)
@@ -65,6 +69,7 @@ export default function CanvasBoard({ canvas, onChange, onCardChange, onCardDele
 
   const handleWheel = (event: React.WheelEvent<HTMLDivElement>) => {
     event.preventDefault()
+    event.stopPropagation()
     const zoomIntensity = 0.0015
     const nextZoom = Math.min(
       MAX_ZOOM,
@@ -90,16 +95,16 @@ export default function CanvasBoard({ canvas, onChange, onCardChange, onCardDele
           {showGrid ? 'Hide grid' : 'Show grid'}
         </button>
         <button
-          onClick={() => onChange({ ...canvas, zoom: Math.min(canvas.zoom + 0.1, MAX_ZOOM) })}
-          className="rounded-2xl bg-white/70 px-3 py-1 text-xs text-slate-600 shadow-sm hover:bg-white dark:bg-slate-900/70 dark:text-slate-300"
-        >
-          +
-        </button>
-        <button
           onClick={() => onChange({ ...canvas, zoom: Math.max(canvas.zoom - 0.1, MIN_ZOOM) })}
           className="rounded-2xl bg-white/70 px-3 py-1 text-xs text-slate-600 shadow-sm hover:bg-white dark:bg-slate-900/70 dark:text-slate-300"
         >
           –
+        </button>
+        <button
+          onClick={() => onChange({ ...canvas, zoom: Math.min(canvas.zoom + 0.1, MAX_ZOOM) })}
+          className="rounded-2xl bg-white/70 px-3 py-1 text-xs text-slate-600 shadow-sm hover:bg-white dark:bg-slate-900/70 dark:text-slate-300"
+        >
+          +
         </button>
         <button
           onClick={() => onChange({ ...canvas, zoom: 1, position: { x: 0, y: 0 } })}
@@ -136,6 +141,7 @@ export default function CanvasBoard({ canvas, onChange, onCardChange, onCardDele
           {canvas.cards.map((card) => (
             <Rnd
               key={card.id}
+              data-card-root="true"
               position={{ x: card.x, y: card.y }}
               size={{ width: card.width, height: card.height }}
               onDragStop={(event, data) => {

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,14 +1,13 @@
 import { useState } from 'react'
 import { Card, QuestionFieldState } from '../lib/storage'
 import { createId } from '../lib/id'
+import { quickTags } from '../lib/tags'
 
 interface CardProps {
   card: Card
   onChange: (card: Card) => void
   onDelete: () => void
 }
-
-const quickTags = ['pain', 'impact', 'req', 'objection', 'next']
 
 export default function CardComponent({ card, onChange, onDelete }: CardProps) {
   const [editingTitle, setEditingTitle] = useState(false)
@@ -190,7 +189,7 @@ export default function CardComponent({ card, onChange, onDelete }: CardProps) {
   }
 
   return (
-    <div className={baseClasses}>
+    <div className={baseClasses} data-card-root="true">
       <div className="mb-2 flex items-start justify-between">
         {editingTitle ? (
           <input

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,4 +1,10 @@
-import { ArrowUturnLeftIcon, ArrowUturnRightIcon, ArrowDownTrayIcon, ArrowUpOnSquareIcon } from '@heroicons/react/24/outline'
+import {
+  ArrowUturnLeftIcon,
+  ArrowUturnRightIcon,
+  ArrowDownTrayIcon,
+  ArrowUpOnSquareIcon,
+  PhoneArrowUpRightIcon
+} from '@heroicons/react/24/outline'
 import { strings } from '../lib/i18n'
 
 interface ToolbarProps {
@@ -7,9 +13,19 @@ interface ToolbarProps {
   onExportJson: () => void
   onExportText: () => void
   onImport: () => void
+  onToggleCallMode?: () => void
+  callModeActive?: boolean
 }
 
-export default function Toolbar({ onUndo, onRedo, onExportJson, onExportText, onImport }: ToolbarProps) {
+export default function Toolbar({
+  onUndo,
+  onRedo,
+  onExportJson,
+  onExportText,
+  onImport,
+  onToggleCallMode,
+  callModeActive
+}: ToolbarProps) {
   return (
     <div className="glass-panel flex flex-wrap items-center gap-3 p-4">
       <button
@@ -24,7 +40,19 @@ export default function Toolbar({ onUndo, onRedo, onExportJson, onExportText, on
       >
         <ArrowUturnRightIcon className="h-4 w-4" /> {strings.actionRedo}
       </button>
-      <div className="ml-auto flex gap-2">
+      <div className="ml-auto flex flex-wrap gap-2">
+        {onToggleCallMode && (
+          <button
+            onClick={onToggleCallMode}
+            className={`inline-flex items-center gap-2 rounded-2xl px-3 py-2 text-xs font-semibold transition ${
+              callModeActive
+                ? 'bg-indigo-500 text-white shadow'
+                : 'bg-indigo-500/10 text-indigo-600 hover:bg-indigo-500/20 dark:text-indigo-200'
+            }`}
+          >
+            <PhoneArrowUpRightIcon className="h-4 w-4" /> {callModeActive ? 'Exit call mode' : 'Call mode'}
+          </button>
+        )}
         <button
           onClick={onImport}
           className="inline-flex items-center gap-2 rounded-2xl bg-indigo-500/10 px-3 py-2 text-xs font-semibold text-indigo-600 hover:bg-indigo-500/20 dark:text-indigo-200"

--- a/src/lib/questions.ts
+++ b/src/lib/questions.ts
@@ -1,0 +1,96 @@
+import {
+  Card,
+  FieldValue,
+  QuestionFieldState,
+  QuestionVariant,
+  ScriptInput,
+  ScriptQuestion
+} from './storage'
+import { createId } from './id'
+
+function cloneFieldValue(value: FieldValue): FieldValue {
+  if (Array.isArray(value)) {
+    return [...value]
+  }
+  if (typeof value === 'object' && value !== null) {
+    return JSON.parse(JSON.stringify(value))
+  }
+  return value
+}
+
+export function initializeFieldState(input: ScriptInput): QuestionFieldState {
+  let value: FieldValue
+  switch (input.type) {
+    case 'checkbox':
+      value = Boolean(input.defaultValue)
+      break
+    case 'multiSelect':
+    case 'tags':
+      value = Array.isArray(input.defaultValue) ? [...input.defaultValue] : []
+      break
+    case 'number':
+      value = typeof input.defaultValue === 'number' ? input.defaultValue : null
+      break
+    default:
+      value =
+        typeof input.defaultValue === 'string'
+          ? input.defaultValue
+          : input.defaultValue == null
+            ? ''
+            : String(input.defaultValue)
+  }
+  return { ...input, value }
+}
+
+interface CreateQuestionCardOptions {
+  question: ScriptQuestion
+  variant: QuestionVariant
+  answer?: string
+  extraTags?: string[]
+  fields?: QuestionFieldState[]
+  position?: { x: number; y: number }
+}
+
+export function createQuestionCard({
+  question,
+  variant,
+  answer = '',
+  extraTags = [],
+  fields,
+  position
+}: CreateQuestionCardOptions): Card {
+  const now = new Date().toISOString()
+  const normalizedTags = Array.from(
+    new Set([
+      'question',
+      ...question.tags.map((tag) => tag.toLowerCase()),
+      ...extraTags.map((tag) => tag.toLowerCase())
+    ])
+  )
+
+  const resolvedFields = fields
+    ? fields.map((field) => ({ ...field, value: cloneFieldValue(field.value) }))
+    : question.inputs?.map((input) => initializeFieldState(input))
+
+  return {
+    id: createId('card'),
+    type: 'question',
+    title: question.label,
+    content: variant.text,
+    answer,
+    variants: question.variants.map((option) => ({ ...option })),
+    tags: normalizedTags,
+    questionId: question.id,
+    fields: resolvedFields,
+    pinned: false,
+    locked: false,
+    color: '#e0e7ff',
+    priority: 'medium',
+    x: position?.x ?? Math.random() * 160,
+    y: position?.y ?? Math.random() * 160,
+    width: 260,
+    height: 200,
+    createdAt: now,
+    updatedAt: now
+  }
+}

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -1,0 +1,3 @@
+export const quickTags = ['pain', 'impact', 'req', 'objection', 'next'] as const
+
+export type QuickTag = typeof quickTags[number]

--- a/src/routes/Project.tsx
+++ b/src/routes/Project.tsx
@@ -4,6 +4,7 @@ import { PlusIcon, ArrowLeftIcon } from '@heroicons/react/24/outline'
 import { StoreContext } from '../App'
 import { strings } from '../lib/i18n'
 import { createEmptyCanvas } from '../lib/storage'
+import { createQuestionCard } from '../lib/questions'
 
 export default function ProjectRoute() {
   const { projectId } = useParams()
@@ -34,8 +35,8 @@ export default function ProjectRoute() {
   return (
     <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
       <section className="glass-panel space-y-6 p-6">
-        <header className="flex items-start justify-between gap-4">
-          <div>
+        <header className="flex flex-wrap items-start justify-between gap-4">
+          <div className="flex-1">
             <input
               value={renameValue}
               onChange={(event) => setRenameValue(event.target.value)}
@@ -46,14 +47,24 @@ export default function ProjectRoute() {
               {project.tags.length > 0 ? project.tags.join(' • ') : 'Add tags via card quick tags.'}
             </p>
           </div>
-          <button
-            onClick={() => {
-              store.saveSnapshot(project.id, 'Manual save')
-            }}
-            className="rounded-2xl bg-indigo-500/10 px-3 py-2 text-xs font-semibold text-indigo-600 hover:bg-indigo-500/20 dark:text-indigo-200"
-          >
-            {strings.actionSave}
-          </button>
+          <div className="flex flex-wrap items-center gap-2">
+            {project.canvases[0] && (
+              <button
+                onClick={() => navigate(`/project/${project.id}/canvas/${project.canvases[0].id}`, { state: { callMode: true } })}
+                className="rounded-2xl bg-emerald-500/10 px-3 py-2 text-xs font-semibold text-emerald-600 transition hover:bg-emerald-500/20 dark:text-emerald-200"
+              >
+                Start call mode
+              </button>
+            )}
+            <button
+              onClick={() => {
+                store.saveSnapshot(project.id, 'Manual save')
+              }}
+              className="rounded-2xl bg-indigo-500/10 px-3 py-2 text-xs font-semibold text-indigo-600 hover:bg-indigo-500/20 dark:text-indigo-200"
+            >
+              {strings.actionSave}
+            </button>
+          </div>
         </header>
 
         <div className="rounded-3xl border border-slate-200/60 bg-white/70 p-4 dark:border-slate-700/60 dark:bg-slate-900/70">
@@ -178,25 +189,8 @@ export default function ProjectRoute() {
                             onClick={() => {
                               if (!project.canvases[0]) return
                               const canvas = project.canvases[0]
-                              store.addCard(project.id, canvas.id, {
-                                id: variant.id,
-                                type: 'question',
-                                title: question.label,
-                                content: variant.text,
-                                tags: question.tags,
-                                pinned: false,
-                                locked: false,
-                                color: '#e0e7ff',
-                                priority: 'medium',
-                                x: Math.random() * 100,
-                                y: Math.random() * 100,
-                                width: 260,
-                                height: 200,
-                                createdAt: new Date().toISOString(),
-                                updatedAt: new Date().toISOString(),
-                                answer: '',
-                                variants: question.variants,
-                              })
+                              const card = createQuestionCard({ question, variant })
+                              store.addCard(project.id, canvas.id, card)
                             }}
                             className="block w-full rounded-2xl bg-indigo-500/10 px-3 py-2 text-left text-xs text-indigo-600 transition hover:bg-indigo-500/20 dark:text-indigo-200"
                           >


### PR DESCRIPTION
## Summary
- add an interactive call mode overlay with question guidance, logging, and entry points from the toolbar and project page
- refactor question-card creation utilities and share quick tag constants for consistent tagging
- improve canvas interactions by preventing accidental panning/scrolling and reordering zoom controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e554221f488326ad281fd78ccf1567