### PR TITLE
Improve call mode flexibility and card placement

### DIFF
--- a/src/lib/canvasLayout.ts
+++ b/src/lib/canvasLayout.ts
@@ -16,7 +16,9 @@ interface Positionable {
   y: number
 }
 
-export function findNextGridPosition<T extends Positionable>(cards: T[]): { x: number; y: number } {
+export function findNextGridPositionWithOverflow<T extends Positionable>(
+  cards: T[]
+): { position: { x: number; y: number }; overflowed: boolean } {
   const occupied = new Set(
     cards.map((card) => {
       const snapped = snapPointToGrid({ x: card.x, y: card.y })
@@ -30,7 +32,10 @@ export function findNextGridPosition<T extends Positionable>(cards: T[]): { x: n
     for (let col = 0; col < searchLimit; col += 1) {
       const key = `${col}:${row}`
       if (!occupied.has(key)) {
-        return { x: col * GRID_SPACING, y: row * GRID_SPACING }
+        return {
+          position: { x: col * GRID_SPACING, y: row * GRID_SPACING },
+          overflowed: false
+        }
       }
     }
   }
@@ -38,5 +43,12 @@ export function findNextGridPosition<T extends Positionable>(cards: T[]): { x: n
   const fallbackIndex = cards.length + 1
   const fallbackRow = Math.floor(fallbackIndex / searchLimit)
   const fallbackCol = fallbackIndex % searchLimit
-  return { x: fallbackCol * GRID_SPACING, y: fallbackRow * GRID_SPACING }
+  return {
+    position: { x: fallbackCol * GRID_SPACING, y: fallbackRow * GRID_SPACING },
+    overflowed: true
+  }
+}
+
+export function findNextGridPosition<T extends Positionable>(cards: T[]): { x: number; y: number } {
+  return findNextGridPositionWithOverflow(cards).position
 }


### PR DESCRIPTION
## Summary
- add an overflow-aware grid placement helper so new cards find open positions
- update call mode to support Enter-to-save, manual question jumps, and freeform note capture
- record flexible history entries and auto zoom out when the grid is saturated

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5825c7b5c832687b64e45831687aa