### PR TITLE
Add Gemini API tester to settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ The included workflow in `.github/workflows/deploy.yml` builds the app and publi
 - Adjust the three starter templates in `src/lib/templates.ts`.
 - Localize strings in `src/lib/i18n.ts`.
 
+### Try your Gemini API key
+
+Head to the **Settings** page from the sidebar to find the Gemini API tester card. Paste a valid API key, enter a prompt, and send a test request to confirm your credentials. The call is made straight from your browser using the official REST endpoint, so avoid sharing keys you would not be comfortable exposing client-side.
+
 ## Future roadmap
 
 - **Real-time collaboration:** Introduce a multiplayer canvas powered by a CRDT engine such as [Yjs](https://yjs.dev/) to keep cards, scripts, and guided prompts in sync across participants. Pair the CRDT document with awareness metadata so teams can see who is editing in real time.

--- a/gemini_quickstart.py
+++ b/gemini_quickstart.py
@@ -7,15 +7,17 @@ import subprocess
 import sys
 
 # Ensure google-genai is installed/up to date. The -q flag keeps pip quiet.
-subprocess.check_call([
-    sys.executable,
-    "-m",
-    "pip",
-    "install",
-    "-q",
-    "-U",
-    "google-genai",
-])
+subprocess.check_call(
+    [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "-q",
+        "-U",
+        "google-genai",
+    ]
+)
 
 from google import genai
 
@@ -25,7 +27,7 @@ def main() -> None:
 
     # Replace the placeholder below with your actual Gemini API key before running
     # this script.
-    api_key = "AIzaSyCNhEJt6wbopVGULGiuYmbPsXWh9DSBHOc"
+    api_key = "YOUR_GEMINI_API_KEY"
 
     # Initialize the client. Passing the key explicitly makes it clear which
     # credentials are being used.

--- a/src/components/GeminiTestCard.tsx
+++ b/src/components/GeminiTestCard.tsx
@@ -1,0 +1,184 @@
+import { FormEvent, useMemo, useState } from "react";
+
+interface GeminiTestCardProps {
+  className?: string;
+}
+
+type GeminiGenerateResponse = {
+  candidates?: Array<{
+    content?: {
+      parts?: Array<{
+        text?: string;
+      }>;
+    };
+  }>;
+  promptFeedback?: {
+    blockReason?: string;
+  };
+  [key: string]: unknown;
+};
+
+export default function GeminiTestCard({
+  className = "",
+}: GeminiTestCardProps) {
+  const [apiKey, setApiKey] = useState("");
+  const [prompt, setPrompt] = useState("");
+  const [response, setResponse] = useState<string | null>(null);
+  const [rawResponse, setRawResponse] = useState<GeminiGenerateResponse | null>(
+    null,
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const hasResponseText = useMemo(
+    () => typeof response === "string" && response.trim().length > 0,
+    [response],
+  );
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!apiKey.trim()) {
+      setError("Please enter your Gemini API key before sending a prompt.");
+      return;
+    }
+
+    if (!prompt.trim()) {
+      setError("Add a prompt so Gemini knows what to respond to.");
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+    setResponse(null);
+    setRawResponse(null);
+
+    try {
+      const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${encodeURIComponent(
+        apiKey.trim(),
+      )}`;
+
+      const res = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          contents: [
+            {
+              parts: [
+                {
+                  text: prompt,
+                },
+              ],
+            },
+          ],
+        }),
+      });
+
+      if (!res.ok) {
+        const errorBody = await res.json().catch(() => null);
+        const message =
+          (errorBody as { error?: { message?: string } } | null)?.error
+            ?.message ?? `Request failed with status ${res.status}`;
+        throw new Error(message);
+      }
+
+      const data: GeminiGenerateResponse = await res.json();
+      setRawResponse(data);
+
+      const textResponse =
+        data.candidates
+          ?.flatMap((candidate) => candidate.content?.parts ?? [])
+          .map((part) => part.text ?? "")
+          .join("\n") ?? "";
+
+      setResponse(textResponse);
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : "Something went wrong while contacting Gemini.";
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <section className={`${className} space-y-4`} aria-live="polite">
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Gemini API tester
+          </h2>
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            Run a quick prompt against{" "}
+            <span className="font-medium text-slate-700 dark:text-slate-200">
+              gemini-2.5-flash
+            </span>{" "}
+            using a client-side request.
+          </p>
+        </div>
+      </div>
+      <form className="space-y-3" onSubmit={handleSubmit}>
+        <div className="space-y-2">
+          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Gemini API key
+          </label>
+          <input
+            type="password"
+            value={apiKey}
+            onChange={(event) => setApiKey(event.target.value)}
+            placeholder="Paste your key here"
+            className="w-full rounded-2xl border border-slate-200/60 bg-white/70 px-4 py-2 text-sm text-slate-700 shadow-sm placeholder:text-slate-400 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700/60 dark:bg-slate-950/40 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-violet-400 dark:focus:ring-violet-500/30"
+          />
+          <p className="text-xs text-slate-400 dark:text-slate-500">
+            The key stays in your browser session and is never stored by VNote.
+          </p>
+        </div>
+        <div className="space-y-2">
+          <label className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Prompt
+          </label>
+          <textarea
+            value={prompt}
+            onChange={(event) => setPrompt(event.target.value)}
+            placeholder="Ask Gemini anything to test your credentials..."
+            rows={4}
+            className="w-full rounded-2xl border border-slate-200/60 bg-white/70 px-4 py-3 text-sm text-slate-700 shadow-sm placeholder:text-slate-400 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700/60 dark:bg-slate-950/40 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-violet-400 dark:focus:ring-violet-500/30"
+          />
+        </div>
+        <button
+          type="submit"
+          className="inline-flex items-center justify-center rounded-2xl bg-gradient-to-r from-indigo-500 to-violet-500 px-4 py-2 text-sm font-semibold text-white shadow-soft transition hover:shadow-glow focus:outline-none focus:ring-2 focus:ring-indigo-400/60 focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-violet-400/60 dark:focus:ring-offset-slate-900 disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={isLoading}
+        >
+          {isLoading ? "Sending…" : "Send test prompt"}
+        </button>
+      </form>
+      <div className="space-y-3">
+        {error ? (
+          <div className="rounded-2xl border border-red-200 bg-red-50/80 px-4 py-3 text-sm text-red-600 dark:border-red-900/70 dark:bg-red-950/40 dark:text-red-300">
+            {error}
+          </div>
+        ) : null}
+        {!error && hasResponseText ? (
+          <div className="rounded-2xl border border-slate-200/80 bg-white/80 px-4 py-3 text-sm shadow-sm dark:border-slate-800/80 dark:bg-slate-950/40">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              Response
+            </h3>
+            <pre className="mt-2 max-h-72 overflow-auto whitespace-pre-wrap text-sm text-slate-700 dark:text-slate-200">
+              {response}
+            </pre>
+          </div>
+        ) : null}
+        {!error && !isLoading && !hasResponseText && rawResponse ? (
+          <div className="rounded-2xl border border-amber-200 bg-amber-50/80 px-4 py-3 text-sm text-amber-700 dark:border-amber-900/70 dark:bg-amber-950/40 dark:text-amber-300">
+            Gemini responded without any text output.
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -1,53 +1,63 @@
-import { ThemeState } from '../lib/theme'
+import { ThemeState } from "../lib/theme";
+import GeminiTestCard from "../components/GeminiTestCard";
 
 interface SettingsProps {
-  theme: ThemeState
-  onThemeChange: (theme: ThemeState) => void
+  theme: ThemeState;
+  onThemeChange: (theme: ThemeState) => void;
 }
 
 export default function SettingsRoute({ theme, onThemeChange }: SettingsProps) {
   return (
     <div className="glass-panel mx-auto max-w-3xl space-y-6 p-6">
       <header>
-        <h1 className="text-2xl font-semibold text-slate-800 dark:text-white">Settings</h1>
-        <p className="text-sm text-slate-500 dark:text-slate-400">Personalize how VNote feels while you work.</p>
+        <h1 className="text-2xl font-semibold text-slate-800 dark:text-white">
+          Settings
+        </h1>
+        <p className="text-sm text-slate-500 dark:text-slate-400">
+          Personalize how VNote feels while you work.
+        </p>
       </header>
       <section className="space-y-4">
         <div className="rounded-3xl bg-white/70 p-4 shadow-sm dark:bg-slate-900/70">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Theme</h2>
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Theme
+          </h2>
           <div className="mt-3 flex gap-3">
             <button
-              onClick={() => onThemeChange({ ...theme, mode: 'light' })}
-              className={`rounded-2xl px-4 py-2 text-sm font-semibold ${theme.mode === 'light' ? 'bg-indigo-500 text-white' : 'bg-slate-200/60 text-slate-600 dark:bg-slate-800/60 dark:text-slate-200'}`}
+              onClick={() => onThemeChange({ ...theme, mode: "light" })}
+              className={`rounded-2xl px-4 py-2 text-sm font-semibold ${theme.mode === "light" ? "bg-indigo-500 text-white" : "bg-slate-200/60 text-slate-600 dark:bg-slate-800/60 dark:text-slate-200"}`}
             >
               Light
             </button>
             <button
-              onClick={() => onThemeChange({ ...theme, mode: 'dark' })}
-              className={`rounded-2xl px-4 py-2 text-sm font-semibold ${theme.mode === 'dark' ? 'bg-indigo-500 text-white' : 'bg-slate-200/60 text-slate-600 dark:bg-slate-800/60 dark:text-slate-200'}`}
+              onClick={() => onThemeChange({ ...theme, mode: "dark" })}
+              className={`rounded-2xl px-4 py-2 text-sm font-semibold ${theme.mode === "dark" ? "bg-indigo-500 text-white" : "bg-slate-200/60 text-slate-600 dark:bg-slate-800/60 dark:text-slate-200"}`}
             >
               Dark
             </button>
           </div>
         </div>
         <div className="rounded-3xl bg-white/70 p-4 shadow-sm dark:bg-slate-900/70">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Accent</h2>
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Accent
+          </h2>
           <div className="mt-3 flex gap-3">
             <button
-              onClick={() => onThemeChange({ ...theme, accent: 'indigo' })}
-              className={`rounded-2xl px-4 py-2 text-sm font-semibold ${theme.accent === 'indigo' ? 'bg-indigo-500 text-white' : 'bg-slate-200/60 text-slate-600 dark:bg-slate-800/60 dark:text-slate-200'}`}
+              onClick={() => onThemeChange({ ...theme, accent: "indigo" })}
+              className={`rounded-2xl px-4 py-2 text-sm font-semibold ${theme.accent === "indigo" ? "bg-indigo-500 text-white" : "bg-slate-200/60 text-slate-600 dark:bg-slate-800/60 dark:text-slate-200"}`}
             >
               Indigo
             </button>
             <button
-              onClick={() => onThemeChange({ ...theme, accent: 'violet' })}
-              className={`rounded-2xl px-4 py-2 text-sm font-semibold ${theme.accent === 'violet' ? 'bg-violet-500 text-white' : 'bg-slate-200/60 text-slate-600 dark:bg-slate-800/60 dark:text-slate-200'}`}
+              onClick={() => onThemeChange({ ...theme, accent: "violet" })}
+              className={`rounded-2xl px-4 py-2 text-sm font-semibold ${theme.accent === "violet" ? "bg-violet-500 text-white" : "bg-slate-200/60 text-slate-600 dark:bg-slate-800/60 dark:text-slate-200"}`}
             >
               Violet
             </button>
           </div>
         </div>
+        <GeminiTestCard className="rounded-3xl bg-white/70 p-4 shadow-sm dark:bg-slate-900/70" />
       </section>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- add a Gemini API tester card component with key entry, prompt form, and REST call handling
- surface the tester from the Settings page alongside the existing theme controls
- document how to try keys and ship a quickstart python script for the google-genai client

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e59589b0b08326a372bbce60f1473c