### PR TITLE
Allow prefilled Gemini tester API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The included workflow in `.github/workflows/deploy.yml` builds the app and publi
 
 ### Try your Gemini API key
 
-Head to the **Settings** page from the sidebar to find the Gemini API tester card. Paste a valid API key, enter a prompt, and send a test request to confirm your credentials. The call is made straight from your browser using the official REST endpoint, so avoid sharing keys you would not be comfortable exposing client-side.
+Head to the **Settings** page from the sidebar to find the Gemini API tester card. Paste a valid API key, enter a prompt, and send a test request to confirm your credentials. The call is made straight from your browser using the official REST endpoint, so avoid sharing keys you would not be comfortable exposing client-side. If you prefer to bundle a throwaway key for local testing, update `DEFAULT_GEMINI_API_KEY` in `src/config/gemini.ts`—the tester will pre-fill the input with that value.
 
 ## Future roadmap
 

--- a/src/components/GeminiTestCard.tsx
+++ b/src/components/GeminiTestCard.tsx
@@ -1,5 +1,7 @@
 import { FormEvent, useMemo, useState } from "react";
 
+import { DEFAULT_GEMINI_API_KEY } from "../config/gemini";
+
 interface GeminiTestCardProps {
   className?: string;
 }
@@ -21,7 +23,8 @@ type GeminiGenerateResponse = {
 export default function GeminiTestCard({
   className = "",
 }: GeminiTestCardProps) {
-  const [apiKey, setApiKey] = useState("");
+  const defaultApiKey = DEFAULT_GEMINI_API_KEY.trim();
+  const [apiKey, setApiKey] = useState(defaultApiKey);
   const [prompt, setPrompt] = useState("");
   const [response, setResponse] = useState<string | null>(null);
   const [rawResponse, setRawResponse] = useState<GeminiGenerateResponse | null>(
@@ -38,7 +41,9 @@ export default function GeminiTestCard({
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    if (!apiKey.trim()) {
+    const sanitizedApiKey = (apiKey || defaultApiKey).trim();
+
+    if (!sanitizedApiKey) {
       setError("Please enter your Gemini API key before sending a prompt.");
       return;
     }
@@ -55,7 +60,7 @@ export default function GeminiTestCard({
 
     try {
       const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${encodeURIComponent(
-        apiKey.trim(),
+        sanitizedApiKey,
       )}`;
 
       const res = await fetch(url, {
@@ -134,7 +139,9 @@ export default function GeminiTestCard({
             className="w-full rounded-2xl border border-slate-200/60 bg-white/70 px-4 py-2 text-sm text-slate-700 shadow-sm placeholder:text-slate-400 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-700/60 dark:bg-slate-950/40 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-violet-400 dark:focus:ring-violet-500/30"
           />
           <p className="text-xs text-slate-400 dark:text-slate-500">
-            The key stays in your browser session and is never stored by VNote.
+            The key stays in your browser session and is never stored by VNote. {" "}
+            Pre-fill it by updating DEFAULT_GEMINI_API_KEY in src/config/gemini.ts if you
+            want to avoid pasting it each time.
           </p>
         </div>
         <div className="space-y-2">

--- a/src/config/gemini.ts
+++ b/src/config/gemini.ts
@@ -1,0 +1,8 @@
+/**
+ * Default Gemini API key used by the in-app tester.
+ *
+ * The string is intentionally empty so builds do not ship with credentials by default.
+ * If you want to bundle a key for local testing, replace the empty string with your key.
+ * Avoid using production secrets here because the key will end up in the built client bundle.
+ */
+export const DEFAULT_GEMINI_API_KEY = "";


### PR DESCRIPTION
## Summary
- add a configurable default Gemini API key entry for the tester card
- default to the bundled key when sending requests and update helper copy
- document how to set the default key for local testing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e59e9615848326953fec66f7058dee