### PR TITLE
Prefill Gemini tester with bundled API key

### DIFF
--- a/src/config/gemini.ts
+++ b/src/config/gemini.ts
@@ -1,8 +1,8 @@
 /**
  * Default Gemini API key used by the in-app tester.
  *
- * The string is intentionally empty so builds do not ship with credentials by default.
- * If you want to bundle a key for local testing, replace the empty string with your key.
- * Avoid using production secrets here because the key will end up in the built client bundle.
- */
-export const DEFAULT_GEMINI_API_KEY = "";
+ * The string below uses a throwaway key so the settings tester works out of the box.
+ * Avoid placing production credentials here because the value is bundled client-side
+ * and visible to anyone who can access the app.
+*/
+export const DEFAULT_GEMINI_API_KEY = "AIzaSyCNhEJt6wbopVGULGiuYmbPsXWh9DSBHOc";


### PR DESCRIPTION
## Summary
- bundle the demo Gemini API key so the settings tester works without manual input
- clarify in the config comment that the key is only for throwaway usage

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5a4988e2083269128933e84d03873